### PR TITLE
docs: clarify README branch tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 A command-line tool that generates [D2](https://d2lang.com/) diagram files from Kubernetes cluster topology. Visualize your cluster's namespaces, workloads, services, and their relationships as code.
 
+> Note: This README tracks the `main` branch. If you are using the latest stable release, check the matching Git tag or the [release notes](https://github.com/vieitesss/k8s-d2/releases) for the shipped CLI behavior and flags.
+
 ![k8s-d2 Example Diagram](assets/example.png)
 
 ## Features


### PR DESCRIPTION
## Summary
- add a short note near the top of the README explaining that it tracks the `main` branch
- direct stable-release users to the matching tag or GitHub release notes for shipped CLI behavior and flags

## Testing
- not run (docs-only change)