### PR TITLE
fix: use built-in D2 legend for rendered resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,12 @@ This repo is a Go CLI named `k8sdd` that inspects Kubernetes clusters and render
 - If the current branch is `main`, create a new branch with a name that summarizes the goal before making changes, then create a detailed `PLAN.md` for that work.
 - Before finishing, run the relevant tests. If new behavior was added and no test covers it yet, add the missing coverage.
 - Pay special attention to validation-related coverage in `internal/validation/`.
+- When creating or updating PRs, keep the body minimal: include a short summary and the issue relation (for example `Closes #46`), and omit testing or other boilerplate sections unless the user asks for them.
 
 ## Implementation Notes
 
 - 2026-03-12: Rewrote this file to center the workflow on planning, branch safety, and test verification. The old content described project phases and stack details but did not capture the required `PLAN.md` process.
+- 2026-03-15: PR bodies should stay concise by default in this repo: summary plus issue relation only.
 - Keep adding short notes here when something was wrong, how it was fixed, or what future implementations should remember.
 
 ## Current Plan

--- a/internal/validation/integration_test.go
+++ b/internal/validation/integration_test.go
@@ -28,6 +28,10 @@ func TestD2Output_BasicFromEnv(t *testing.T) {
 		t.Errorf("Syntax validation failed: %v", err)
 	}
 
+	if err := validator.ValidateLegendStructure(); err != nil {
+		t.Errorf("Legend validation failed: %v", err)
+	}
+
 	if err := validator.ValidateResources(); err != nil {
 		t.Errorf("Resource validation failed: %v", err)
 	}
@@ -63,6 +67,10 @@ func TestD2Output_StorageFromEnv(t *testing.T) {
 
 	if err := validator.ValidateSyntax(); err != nil {
 		t.Errorf("Syntax validation failed: %v", err)
+	}
+
+	if err := validator.ValidateLegendStructure(); err != nil {
+		t.Errorf("Legend validation failed: %v", err)
 	}
 
 	if err := validator.ValidateResources(); err != nil {

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -41,6 +41,46 @@ func (v *D2Validator) ValidateSyntax() error {
 	return nil
 }
 
+// ValidateLegendStructure checks that the built-in D2 legend exists when needed
+// and only includes entries for rendered resource types.
+func (v *D2Validator) ValidateLegendStructure() error {
+	expectedEntries := v.expectedLegendEntries()
+	if len(expectedEntries) == 0 {
+		if strings.Contains(v.actual, "d2-legend:") {
+			return fmt.Errorf("unexpected legend block for topology without legend entries")
+		}
+		return nil
+	}
+
+	if !strings.Contains(v.actual, "vars: {") {
+		return fmt.Errorf("missing vars block for legend")
+	}
+
+	legendBlock, err := extractD2Block(v.actual, "d2-legend:")
+	if err != nil {
+		return err
+	}
+
+	expectedSet := make(map[string]struct{}, len(expectedEntries))
+	for _, entry := range expectedEntries {
+		expectedSet[entry] = struct{}{}
+		if !strings.Contains(legendBlock, fmt.Sprintf("%s: {", entry)) {
+			return fmt.Errorf("missing legend entry: %s", entry)
+		}
+	}
+
+	for _, entry := range allLegendEntryIDs() {
+		if _, ok := expectedSet[entry]; ok {
+			continue
+		}
+		if strings.Contains(legendBlock, fmt.Sprintf("%s: {", entry)) {
+			return fmt.Errorf("unexpected legend entry: %s", entry)
+		}
+	}
+
+	return nil
+}
+
 // ValidateResources checks that all expected resources are present in the D2 output
 func (v *D2Validator) ValidateResources() error {
 	for _, ns := range v.expected.Namespaces {
@@ -189,4 +229,75 @@ func (v *D2Validator) ValidateConfigInfo() error {
 	}
 
 	return nil
+}
+
+func (v *D2Validator) expectedLegendEntries() []string {
+	var hasDeployments bool
+	var hasStatefulSets bool
+	var hasDaemonSets bool
+	var hasServices bool
+	var hasConfig bool
+	var hasPVCs bool
+
+	for _, ns := range v.expected.Namespaces {
+		hasDeployments = hasDeployments || len(ns.Deployments) > 0
+		hasStatefulSets = hasStatefulSets || len(ns.StatefulSets) > 0
+		hasDaemonSets = hasDaemonSets || len(ns.DaemonSets) > 0
+		hasServices = hasServices || len(ns.Services) > 0
+		hasConfig = hasConfig || ns.ConfigMaps > 0 || ns.Secrets > 0
+		hasPVCs = hasPVCs || len(ns.PVCs) > 0
+	}
+
+	entries := make([]string, 0, 6)
+	if hasDeployments {
+		entries = append(entries, "deployment")
+	}
+	if hasStatefulSets {
+		entries = append(entries, "statefulset")
+	}
+	if hasDaemonSets {
+		entries = append(entries, "daemonset")
+	}
+	if hasServices {
+		entries = append(entries, "service")
+	}
+	if hasConfig {
+		entries = append(entries, "config")
+	}
+	if hasPVCs {
+		entries = append(entries, "pvc")
+	}
+
+	return entries
+}
+
+func allLegendEntryIDs() []string {
+	return []string{"deployment", "statefulset", "daemonset", "service", "config", "pvc"}
+}
+
+func extractD2Block(input, marker string) (string, error) {
+	markerIndex := strings.Index(input, marker)
+	if markerIndex == -1 {
+		return "", fmt.Errorf("missing %s block", marker)
+	}
+
+	blockStart := strings.Index(input[markerIndex:], "{")
+	if blockStart == -1 {
+		return "", fmt.Errorf("missing opening brace for %s block", marker)
+	}
+
+	braceDepth := 0
+	for i, r := range input[markerIndex+blockStart:] {
+		switch r {
+		case '{':
+			braceDepth++
+		case '}':
+			braceDepth--
+			if braceDepth == 0 {
+				return input[markerIndex : markerIndex+blockStart+i+1], nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unclosed %s block", marker)
 }

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -44,7 +44,7 @@ func (v *D2Validator) ValidateSyntax() error {
 // ValidateLegendStructure checks that the built-in D2 legend exists when needed
 // and only includes entries for rendered resource types.
 func (v *D2Validator) ValidateLegendStructure() error {
-	expectedEntries := v.expectedLegendEntries()
+	expectedEntries := render.LegendEntryIDs(v.expected)
 	if len(expectedEntries) == 0 {
 		if strings.Contains(v.actual, "d2-legend:") {
 			return fmt.Errorf("unexpected legend block for topology without legend entries")
@@ -69,7 +69,7 @@ func (v *D2Validator) ValidateLegendStructure() error {
 		}
 	}
 
-	for _, entry := range allLegendEntryIDs() {
+	for _, entry := range render.AllLegendEntryIDs() {
 		if _, ok := expectedSet[entry]; ok {
 			continue
 		}
@@ -230,51 +230,6 @@ func (v *D2Validator) ValidateConfigInfo() error {
 
 	return nil
 }
-
-func (v *D2Validator) expectedLegendEntries() []string {
-	var hasDeployments bool
-	var hasStatefulSets bool
-	var hasDaemonSets bool
-	var hasServices bool
-	var hasConfig bool
-	var hasPVCs bool
-
-	for _, ns := range v.expected.Namespaces {
-		hasDeployments = hasDeployments || len(ns.Deployments) > 0
-		hasStatefulSets = hasStatefulSets || len(ns.StatefulSets) > 0
-		hasDaemonSets = hasDaemonSets || len(ns.DaemonSets) > 0
-		hasServices = hasServices || len(ns.Services) > 0
-		hasConfig = hasConfig || ns.ConfigMaps > 0 || ns.Secrets > 0
-		hasPVCs = hasPVCs || len(ns.PVCs) > 0
-	}
-
-	entries := make([]string, 0, 6)
-	if hasDeployments {
-		entries = append(entries, "deployment")
-	}
-	if hasStatefulSets {
-		entries = append(entries, "statefulset")
-	}
-	if hasDaemonSets {
-		entries = append(entries, "daemonset")
-	}
-	if hasServices {
-		entries = append(entries, "service")
-	}
-	if hasConfig {
-		entries = append(entries, "config")
-	}
-	if hasPVCs {
-		entries = append(entries, "pvc")
-	}
-
-	return entries
-}
-
-func allLegendEntryIDs() []string {
-	return []string{"deployment", "statefulset", "daemonset", "service", "config", "pvc"}
-}
-
 func extractD2Block(input, marker string) (string, error) {
 	markerIndex := strings.Index(input, marker)
 	if markerIndex == -1 {

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -35,6 +35,12 @@ func TestD2Validator_BasicTopology(t *testing.T) {
 		}
 	})
 
+	t.Run("ValidateLegendStructure", func(t *testing.T) {
+		if err := validator.ValidateLegendStructure(); err != nil {
+			t.Errorf("Legend validation failed: %v", err)
+		}
+	})
+
 	t.Run("ValidateResources", func(t *testing.T) {
 		if err := validator.ValidateResources(); err != nil {
 			t.Errorf("Resource validation failed: %v", err)
@@ -81,6 +87,12 @@ func TestD2Validator_WithStorage(t *testing.T) {
 	t.Run("ValidateSyntax", func(t *testing.T) {
 		if err := validator.ValidateSyntax(); err != nil {
 			t.Errorf("Syntax validation failed: %v", err)
+		}
+	})
+
+	t.Run("ValidateLegendStructure", func(t *testing.T) {
+		if err := validator.ValidateLegendStructure(); err != nil {
+			t.Errorf("Legend validation failed: %v", err)
 		}
 	})
 

--- a/pkg/render/d2.go
+++ b/pkg/render/d2.go
@@ -33,7 +33,7 @@ direction: right
 		return err
 	}
 
-	if err := r.renderLegend(); err != nil {
+	if err := r.renderLegend(cluster); err != nil {
 		return err
 	}
 
@@ -198,52 +198,104 @@ func (r *D2Renderer) writeServiceConnections(b *strings.Builder, svc *model.Serv
 	}
 }
 
-func (r *D2Renderer) renderLegend() error {
-	legend := `
-legend: {
-  label: "LEGEND"
-  grid-rows: 1
-  style.fill: "#fffacd"
-  style.stroke: "#000000"
-  style.stroke-width: 3
-  style.font-size: 16
-  style.bold: true
+func (r *D2Renderer) renderLegend(cluster *model.Cluster) error {
+	entries := legendEntries(cluster)
+	if len(entries) == 0 {
+		return nil
+	}
 
-  deployment: {
-    label: "● Deployment"
-    style.fill: "#f9f9f9"
-  }
+	var b strings.Builder
+	b.WriteString("vars: {\n  d2-legend: {\n")
 
-  statefulset: {
-    label: "◉ StatefulSet"
-    style.fill: "#f9f9f9"
-  }
+	for i, entry := range entries {
+		fmt.Fprintf(&b, "    %s: {\n", entry.id)
+		fmt.Fprintf(&b, "      label: %q\n", entry.label)
+		if entry.fill != "" {
+			fmt.Fprintf(&b, "      style.fill: %q\n", entry.fill)
+		}
+		b.WriteString("    }\n")
+		if i < len(entries)-1 {
+			b.WriteString("\n")
+		}
+	}
 
-  daemonset: {
-    label: "◈ DaemonSet"
-    style.fill: "#f9f9f9"
-  }
+	b.WriteString("  }\n}\n\n")
 
-  service: {
-    label: "⎈ Service"
-    style.fill: "#cce5ff"
-  }
-
-  config: {
-    label: "ConfigMaps | Secrets"
-    style.fill: "#ffffcc"
-  }
-
-  pvc: {
-    label: "💾 PVC"
-    style.fill: "#e6f3ff"
-  }
-}
-`
-	if _, err := fmt.Fprint(r.w, legend); err != nil {
+	if _, err := fmt.Fprint(r.w, b.String()); err != nil {
 		return err
 	}
+
 	return nil
+}
+
+type legendEntry struct {
+	id    string
+	label string
+	fill  string
+}
+
+func legendEntries(cluster *model.Cluster) []legendEntry {
+	var hasDeployments bool
+	var hasStatefulSets bool
+	var hasDaemonSets bool
+	var hasServices bool
+	var hasConfig bool
+	var hasPVCs bool
+
+	for _, ns := range cluster.Namespaces {
+		hasDeployments = hasDeployments || len(ns.Deployments) > 0
+		hasStatefulSets = hasStatefulSets || len(ns.StatefulSets) > 0
+		hasDaemonSets = hasDaemonSets || len(ns.DaemonSets) > 0
+		hasServices = hasServices || len(ns.Services) > 0
+		hasConfig = hasConfig || ns.ConfigMaps > 0 || ns.Secrets > 0
+		hasPVCs = hasPVCs || len(ns.PVCs) > 0
+	}
+
+	entries := make([]legendEntry, 0, 6)
+	if hasDeployments {
+		entries = append(entries, legendEntry{
+			id:    "deployment",
+			label: fmt.Sprintf("%s Deployment", WorkloadIcon("Deployment")),
+			fill:  "#f9f9f9",
+		})
+	}
+	if hasStatefulSets {
+		entries = append(entries, legendEntry{
+			id:    "statefulset",
+			label: fmt.Sprintf("%s StatefulSet", WorkloadIcon("StatefulSet")),
+			fill:  "#f9f9f9",
+		})
+	}
+	if hasDaemonSets {
+		entries = append(entries, legendEntry{
+			id:    "daemonset",
+			label: fmt.Sprintf("%s DaemonSet", WorkloadIcon("DaemonSet")),
+			fill:  "#f9f9f9",
+		})
+	}
+	if hasServices {
+		entries = append(entries, legendEntry{
+			id:    "service",
+			label: "⎈ Service",
+			fill:  "#cce5ff",
+		})
+	}
+	if hasConfig {
+		entries = append(entries, legendEntry{
+			id:    "config",
+			label: "ConfigMaps | Secrets",
+			fill:  "#ffffcc",
+		})
+	}
+	if hasPVCs {
+		entries = append(entries, legendEntry{
+			id:    "pvc",
+			label: "💾 PVC",
+			fill:  "#e6f3ff",
+		})
+	}
+
+	return entries
 }
 
 // SanitizeID converts a Kubernetes resource name to a valid D2 identifier.

--- a/pkg/render/d2.go
+++ b/pkg/render/d2.go
@@ -234,6 +234,30 @@ type legendEntry struct {
 	fill  string
 }
 
+var allLegendEntryIDs = []string{
+	"deployment",
+	"statefulset",
+	"daemonset",
+	"service",
+	"config",
+	"pvc",
+}
+
+// LegendEntryIDs returns the legend entry IDs that should be rendered for the cluster.
+func LegendEntryIDs(cluster *model.Cluster) []string {
+	entries := legendEntries(cluster)
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		ids = append(ids, entry.id)
+	}
+	return ids
+}
+
+// AllLegendEntryIDs returns all supported legend entry IDs.
+func AllLegendEntryIDs() []string {
+	return append([]string(nil), allLegendEntryIDs...)
+}
+
 func legendEntries(cluster *model.Cluster) []legendEntry {
 	var hasDeployments bool
 	var hasStatefulSets bool

--- a/pkg/render/d2_test.go
+++ b/pkg/render/d2_test.go
@@ -86,8 +86,13 @@ func TestRenderLegend_IncludesOnlyRenderedResourceTypes(t *testing.T) {
 				return
 			}
 
-			if !strings.Contains(output, "vars: {\n  d2-legend: {") {
-				t.Fatalf("expected built-in legend vars block, output was:\n%s", output)
+			if !strings.Contains(output, "d2-legend:") {
+				t.Fatalf("expected built-in legend block, output was:\n%s", output)
+			}
+
+			varsBlock := extractBlockFromMarker(t, output, "vars:")
+			if !strings.Contains(varsBlock, "d2-legend:") {
+				t.Fatalf("expected legend inside vars block, output was:\n%s", output)
 			}
 
 			legendBlock := extractBlockFromMarker(t, output, "d2-legend:")

--- a/pkg/render/d2_test.go
+++ b/pkg/render/d2_test.go
@@ -1,0 +1,148 @@
+package render
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vieitesss/k8s-d2/pkg/model"
+)
+
+func TestRenderLegend_IncludesOnlyRenderedResourceTypes(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    *model.Cluster
+		expected   []string
+		unexpected []string
+		wantLegend bool
+	}{
+		{
+			name: "deployment only",
+			cluster: &model.Cluster{
+				Namespaces: []model.Namespace{{
+					Name: "apps",
+					Deployments: []model.Workload{{
+						Name:     "web",
+						Kind:     "Deployment",
+						Replicas: 1,
+					}},
+				}},
+			},
+			expected:   []string{"deployment"},
+			unexpected: []string{"statefulset", "daemonset", "service", "config", "pvc"},
+			wantLegend: true,
+		},
+		{
+			name: "service and config only",
+			cluster: &model.Cluster{
+				Namespaces: []model.Namespace{{
+					Name: "apps",
+					Services: []model.Service{{
+						Name: "web-service",
+						Type: "ClusterIP",
+					}},
+					ConfigMaps: 1,
+				}},
+			},
+			expected:   []string{"service", "config"},
+			unexpected: []string{"deployment", "statefulset", "daemonset", "pvc"},
+			wantLegend: true,
+		},
+		{
+			name: "pvc only",
+			cluster: &model.Cluster{
+				Namespaces: []model.Namespace{{
+					Name: "storage",
+					PVCs: []model.PVC{{
+						Name: "data",
+					}},
+				}},
+			},
+			expected:   []string{"pvc"},
+			unexpected: []string{"deployment", "statefulset", "daemonset", "service", "config"},
+			wantLegend: true,
+		},
+		{
+			name: "empty namespace omits legend",
+			cluster: &model.Cluster{
+				Namespaces: []model.Namespace{{
+					Name: "empty",
+				}},
+			},
+			unexpected: []string{"deployment", "statefulset", "daemonset", "service", "config", "pvc"},
+			wantLegend: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := renderTestCluster(t, tt.cluster)
+
+			if !tt.wantLegend {
+				if strings.Contains(output, "d2-legend:") {
+					t.Fatalf("expected legend to be omitted, output was:\n%s", output)
+				}
+				return
+			}
+
+			if !strings.Contains(output, "vars: {\n  d2-legend: {") {
+				t.Fatalf("expected built-in legend vars block, output was:\n%s", output)
+			}
+
+			legendBlock := extractBlockFromMarker(t, output, "d2-legend:")
+			for _, entry := range tt.expected {
+				if !strings.Contains(legendBlock, fmt.Sprintf("%s: {", entry)) {
+					t.Errorf("expected legend entry %q in block:\n%s", entry, legendBlock)
+				}
+			}
+			for _, entry := range tt.unexpected {
+				if strings.Contains(legendBlock, fmt.Sprintf("%s: {", entry)) {
+					t.Errorf("did not expect legend entry %q in block:\n%s", entry, legendBlock)
+				}
+			}
+		})
+	}
+}
+
+func renderTestCluster(t *testing.T, cluster *model.Cluster) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	renderer := NewD2Renderer(&buf, 0)
+	if err := renderer.Render(cluster); err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	return buf.String()
+}
+
+func extractBlockFromMarker(t *testing.T, input, marker string) string {
+	t.Helper()
+
+	markerIndex := strings.Index(input, marker)
+	if markerIndex == -1 {
+		t.Fatalf("missing marker %q in output:\n%s", marker, input)
+	}
+
+	blockStart := strings.Index(input[markerIndex:], "{")
+	if blockStart == -1 {
+		t.Fatalf("missing opening brace for marker %q in output:\n%s", marker, input)
+	}
+
+	braceDepth := 0
+	for i, r := range input[markerIndex+blockStart:] {
+		switch r {
+		case '{':
+			braceDepth++
+		case '}':
+			braceDepth--
+			if braceDepth == 0 {
+				return input[markerIndex : markerIndex+blockStart+i+1]
+			}
+		}
+	}
+
+	t.Fatalf("unclosed block for marker %q in output:\n%s", marker, input)
+	return ""
+}


### PR DESCRIPTION
## Summary
- switch legend rendering to D2's built-in `vars.d2-legend` block
- only include legend entries for resource types that are actually rendered, and omit the legend when nothing should appear
- add renderer and validation coverage for selective legend entries in both unit and env-backed validation tests

Closes #46