### PR TITLE
feat: add fixture-backed dagger image export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,4 @@ jobs:
             --docker-socket /var/run/docker.sock
             --kind-svc tcp://localhost:3000
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
-          version: "v0.19.7"
+          version: "v0.19.10"

--- a/dagger/AGENTS.md
+++ b/dagger/AGENTS.md
@@ -4,4 +4,4 @@
 
 ## Developing Rules
 
-- There is no need to create tests in this Dagger module.
+- Prefer the existing validation flow in this Dagger module; add tests when changing validation behavior.

--- a/dagger/AGENTS.md
+++ b/dagger/AGENTS.md
@@ -1,0 +1,7 @@
+## Docs
+
+- Check https://docs.dagger.io/ and related pages
+
+## Developing Rules
+
+- There is no need to create tests in this Dagger module.

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -72,7 +72,7 @@ The `validate`, `image`, and `image-storage` recipes automatically resolve the A
 Defaults are hardcoded for local use:
 
 - Docker socket: `/var/run/docker.sock`
-- Kubeconfig: `file:///Users/vieitesprefapp/.kube`
+- Kubeconfig: `file://$HOME/.kube`
 
 The only optional parameter is the output filename:
 

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -1,0 +1,84 @@
+# k8sdd Dagger Module
+
+This module runs `k8sdd` against a dummy kind cluster populated from `test/fixtures/`.
+
+It exposes two main functions:
+
+- `run`: applies the fixtures and validates the generated D2 output.
+- `fixture-image`: applies the fixtures and exports the final SVG image.
+
+## Requirements
+
+- `dagger` CLI
+- Docker socket access, usually `/var/run/docker.sock`
+- A reachable kind service address, for example `tcp://localhost:3000`
+
+## Usage
+
+List available functions:
+
+```bash
+dagger functions
+```
+
+Run the validation flow:
+
+```bash
+dagger call run \
+  --docker-socket /var/run/docker.sock \
+  --kind-svc tcp://localhost:3000
+```
+
+Export the fixture-backed SVG image:
+
+```bash
+dagger call fixture-image \
+  --docker-socket /var/run/docker.sock \
+  --kind-svc tcp://localhost:3000 \
+  export --path ./cluster.svg
+```
+
+Export the SVG with storage resources included:
+
+```bash
+dagger call fixture-image \
+  --docker-socket /var/run/docker.sock \
+  --kind-svc tcp://localhost:3000 \
+  --include-storage \
+  export --path ./cluster-with-storage.svg
+```
+
+If you want to connect through an existing kubeconfig directory, add:
+
+```bash
+--kubeconfig file://$HOME/.kube
+```
+
+## Just Recipes
+
+From `dagger/`:
+
+```bash
+just --list
+just cluster
+just validate
+just image
+just image-storage
+```
+
+The `cluster` recipe ensures a local kind cluster named `kind` exists.
+The `validate`, `image`, and `image-storage` recipes automatically resolve the API server port from that cluster.
+
+Defaults are hardcoded for local use:
+
+- Docker socket: `/var/run/docker.sock`
+- Kubeconfig: `file:///Users/vieitesprefapp/.kube`
+
+The only optional parameter is the output filename:
+
+```bash
+just image
+just image custom.svg
+just image-storage
+just image-storage custom-storage.svg
+```

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -15,6 +15,8 @@ It exposes two main functions:
 
 ## Usage
 
+Run these commands from `dagger/`. If you are in the repo root, add `--module ./dagger` to the `dagger` command.
+
 List available functions:
 
 ```bash

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -29,6 +29,15 @@ dagger call run \
   --kind-svc tcp://localhost:3000
 ```
 
+Reuse an existing fixture namespace instead of deleting and recreating it:
+
+```bash
+dagger call run \
+  --docker-socket /var/run/docker.sock \
+  --kind-svc tcp://localhost:3000 \
+  --reuse-namespace
+```
+
 Export the fixture-backed SVG image:
 
 ```bash
@@ -53,6 +62,8 @@ If you want to connect through an existing kubeconfig directory, add:
 ```bash
 --kubeconfig file://$HOME/.kube
 ```
+
+Both `run` and `fixture-image` also accept `--reuse-namespace` when you want to keep working against an already created `k8s-d2-test` namespace.
 
 ## Just Recipes
 

--- a/dagger/dagger.json
+++ b/dagger/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "dagger",
-  "engineVersion": "v0.19.7",
+  "engineVersion": "v0.19.10",
   "sdk": {
     "source": "go"
   },

--- a/dagger/fixtures.go
+++ b/dagger/fixtures.go
@@ -11,6 +11,7 @@ func ApplyFixtures(
 	ctx context.Context,
 	kindContainer *dagger.Container,
 	fixturesDir *dagger.Directory,
+	namespace string,
 	includeStorage bool,
 	reuseNamespace bool,
 ) (*dagger.Container, error) {
@@ -20,7 +21,7 @@ func ApplyFixtures(
 		// Clean up existing namespace to ensure fresh state.
 		kindContainer, err = kindContainer.
 			// Delete namespace if it exists (ignore if not found).
-			WithExec([]string{"kubectl", "delete", "namespace", fixtureNamespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
+			WithExec([]string{"kubectl", "delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
 			Sync(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to clean up namespace: %w", err)
@@ -71,12 +72,12 @@ func ApplyFixtures(
 	// This ensures StatefulSets have created all their PVCs
 	kindContainer, err = kindContainer.
 		// Wait for Deployments
-		WithExec([]string{"kubectl", "rollout", "status", "deployment/web-frontend", "-n", fixtureNamespace, "--timeout=120s"}).
-		WithExec([]string{"kubectl", "rollout", "status", "deployment/api-backend", "-n", fixtureNamespace, "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "deployment/web-frontend", "-n", namespace, "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "deployment/api-backend", "-n", namespace, "--timeout=120s"}).
 		// Wait for StatefulSet (critical for PVC creation)
-		WithExec([]string{"kubectl", "rollout", "status", "statefulset/database", "-n", fixtureNamespace, "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "statefulset/database", "-n", namespace, "--timeout=120s"}).
 		// Wait for DaemonSet
-		WithExec([]string{"kubectl", "rollout", "status", "daemonset/log-collector", "-n", fixtureNamespace, "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "daemonset/log-collector", "-n", namespace, "--timeout=120s"}).
 		Sync(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for workloads to be ready: %w", err)

--- a/dagger/fixtures.go
+++ b/dagger/fixtures.go
@@ -18,7 +18,7 @@ func ApplyFixtures(
 	// Clean up existing namespace to ensure fresh state
 	kindContainer, err = kindContainer.
 		// Delete namespace if it exists (ignore if not found)
-		WithExec([]string{"kubectl", "delete", "namespace", "k8s-d2-test", "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
+		WithExec([]string{"kubectl", "delete", "namespace", fixtureNamespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
 		Sync(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to clean up namespace: %w", err)
@@ -68,12 +68,12 @@ func ApplyFixtures(
 	// This ensures StatefulSets have created all their PVCs
 	kindContainer, err = kindContainer.
 		// Wait for Deployments
-		WithExec([]string{"kubectl", "rollout", "status", "deployment/web-frontend", "-n", "k8s-d2-test", "--timeout=120s"}).
-		WithExec([]string{"kubectl", "rollout", "status", "deployment/api-backend", "-n", "k8s-d2-test", "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "deployment/web-frontend", "-n", fixtureNamespace, "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "deployment/api-backend", "-n", fixtureNamespace, "--timeout=120s"}).
 		// Wait for StatefulSet (critical for PVC creation)
-		WithExec([]string{"kubectl", "rollout", "status", "statefulset/database", "-n", "k8s-d2-test", "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "statefulset/database", "-n", fixtureNamespace, "--timeout=120s"}).
 		// Wait for DaemonSet
-		WithExec([]string{"kubectl", "rollout", "status", "daemonset/log-collector", "-n", "k8s-d2-test", "--timeout=120s"}).
+		WithExec([]string{"kubectl", "rollout", "status", "daemonset/log-collector", "-n", fixtureNamespace, "--timeout=120s"}).
 		Sync(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for workloads to be ready: %w", err)

--- a/dagger/fixtures.go
+++ b/dagger/fixtures.go
@@ -12,16 +12,19 @@ func ApplyFixtures(
 	kindContainer *dagger.Container,
 	fixturesDir *dagger.Directory,
 	includeStorage bool,
+	reuseNamespace bool,
 ) (*dagger.Container, error) {
 	var err error
 
-	// Clean up existing namespace to ensure fresh state
-	kindContainer, err = kindContainer.
-		// Delete namespace if it exists (ignore if not found)
-		WithExec([]string{"kubectl", "delete", "namespace", fixtureNamespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
-		Sync(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to clean up namespace: %w", err)
+	if !reuseNamespace {
+		// Clean up existing namespace to ensure fresh state.
+		kindContainer, err = kindContainer.
+			// Delete namespace if it exists (ignore if not found).
+			WithExec([]string{"kubectl", "delete", "namespace", fixtureNamespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}).
+			Sync(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to clean up namespace: %w", err)
+		}
 	}
 
 	// Apply base fixtures (sorted by filename to ensure correct order)

--- a/dagger/justfile
+++ b/dagger/justfile
@@ -3,7 +3,7 @@ cluster_config := "../test/fixtures/kind-config.yaml"
 control_plane_container := cluster_name + "-control-plane"
 
 docker_socket := "/var/run/docker.sock"
-kubeconfig := "file:///Users/vieitesprefapp/.kube"
+kubeconfig := "file://" + env_var('HOME') + "/.kube"
 
 _default:
 	just --list

--- a/dagger/justfile
+++ b/dagger/justfile
@@ -1,0 +1,46 @@
+cluster_name := "kind"
+cluster_config := "../test/fixtures/kind-config.yaml"
+control_plane_container := cluster_name + "-control-plane"
+
+docker_socket := "/var/run/docker.sock"
+kubeconfig := "file:///Users/vieitesprefapp/.kube"
+
+_default:
+	just --list
+
+cluster:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	if kind get clusters | grep -qx '{{cluster_name}}'; then
+	  echo "kind cluster '{{cluster_name}}' already exists"
+	else
+	  kind create cluster --name '{{cluster_name}}' --config '{{cluster_config}}'
+	fi
+
+_cluster_port:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	docker port '{{control_plane_container}}' 6443/tcp | awk -F: 'NR == 1 { print $NF; exit }'
+
+validate: cluster
+	#!/usr/bin/env bash
+	set -euo pipefail
+	port="$(just --quiet _cluster_port)"
+	args=(dagger call run --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}')
+	"${args[@]}"
+
+image output='cluster.svg': cluster
+	#!/usr/bin/env bash
+	set -euo pipefail
+	port="$(just --quiet _cluster_port)"
+	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}')
+	args+=(export --path '{{output}}')
+	"${args[@]}"
+
+image-storage output='cluster-with-storage.svg': cluster
+	#!/usr/bin/env bash
+	set -euo pipefail
+	port="$(just --quiet _cluster_port)"
+	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}' --include-storage)
+	args+=(export --path '{{output}}')
+	"${args[@]}"

--- a/dagger/justfile
+++ b/dagger/justfile
@@ -33,7 +33,7 @@ image output='cluster.svg': cluster
 	#!/usr/bin/env bash
 	set -euo pipefail
 	port="$(just --quiet _cluster_port)"
-	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}')
+	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}' --reuse-namespace)
 	args+=(export --path '{{output}}')
 	"${args[@]}"
 
@@ -41,6 +41,6 @@ image-storage output='cluster-with-storage.svg': cluster
 	#!/usr/bin/env bash
 	set -euo pipefail
 	port="$(just --quiet _cluster_port)"
-	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}' --include-storage)
+	args=(dagger call fixture-image --docker-socket '{{docker_socket}}' --kind-svc "tcp://localhost:${port}" --kubeconfig '{{kubeconfig}}' --include-storage --reuse-namespace)
 	args+=(export --path '{{output}}')
 	"${args[@]}"

--- a/dagger/k8sddcmd/diagram.go
+++ b/dagger/k8sddcmd/diagram.go
@@ -1,0 +1,14 @@
+package k8sddcmd
+
+// DiagramArgs builds the k8sdd diagram command used by the Dagger module.
+func DiagramArgs(namespace string, outputPath string, includeStorage bool, imageOutput bool) []string {
+	args := []string{"k8sdd", "diagram", "-n", namespace}
+	if includeStorage {
+		args = append(args, "--include-storage")
+	}
+	if imageOutput {
+		return append(args, "--image", outputPath)
+	}
+
+	return append(args, "-o", outputPath)
+}

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -238,6 +238,16 @@ func (m *Dagger) runK8sD2Quiet(
 		return "", fmt.Errorf("quiet mode test failed: stdout should be empty but contains: %s", stdout)
 	}
 
+	// Check stderr for unwanted output.
+	stderr, err := execCtr.File(stderrFile).Contents(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read stderr: %w", err)
+	}
+
+	if stderr != "" {
+		return "", fmt.Errorf("quiet mode test failed: stderr should be empty but contains: %s", stderr)
+	}
+
 	// Get the D2 output
 	output, err := execCtr.File(quietOutputFile).Contents(ctx)
 	if err != nil {

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -8,7 +8,17 @@ package main
 import (
 	"context"
 	"dagger/dagger/internal/dagger"
+	"dagger/dagger/k8sddcmd"
 	"fmt"
+	"strings"
+)
+
+const (
+	fixtureNamespace = "k8s-d2-test"
+	outputDir        = "/output"
+	basicOutputFile  = outputDir + "/test.d2"
+	quietOutputFile  = outputDir + "/test-quiet.d2"
+	imageOutputFile  = outputDir + "/test.svg"
 )
 
 type Dagger struct {
@@ -41,43 +51,90 @@ func (m *Dagger) Run(
 	// +optional
 	kubeconfig *dagger.Directory,
 ) (string, error) {
-	var kindCtr *dagger.Container
-	var err error
-
-	if kubeconfig != nil {
-		kindCtr, err = m.KindFromService(ctx, kindSvc, kubeconfig)
-	} else {
-		kindCtr = m.KindFromModule(dockerSocket, kindSvc)
-	}
+	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kind container: %w", err)
+		return "", err
 	}
 
 	return m.test(ctx, kindCtr)
 }
 
-func (m *Dagger) test(ctx context.Context, kindCtr *dagger.Container) (string, error) {
-	kindBinaryCtr := m.build(kindCtr)
+// FixtureImage returns the SVG generated from the fixture-backed kind cluster.
+func (m *Dagger) FixtureImage(
+	ctx context.Context,
 
+	// Docker socket path
+	dockerSocket *dagger.Socket,
+
+	// Your already created Kind cluster address.
+	// Example: `tcp://localhost:3000`
+	kindSvc *dagger.Service,
+
+	// Directory containing kubeconfig files for your cluster.
+	// Example: `$HOME/.kube`
+	// +optional
+	kubeconfig *dagger.Directory,
+
+	// Include the storage layer in the generated diagram.
+	// +optional
+	includeStorage bool,
+) (*dagger.File, error) {
+	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.runK8sD2Image(kindCtr, includeStorage), nil
+}
+
+func (m *Dagger) fixtureCluster(
+	ctx context.Context,
+	dockerSocket *dagger.Socket,
+	kindSvc *dagger.Service,
+	kubeconfig *dagger.Directory,
+) (*dagger.Container, error) {
+	kindCtr, err := m.kindContainer(ctx, dockerSocket, kindSvc, kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kind container: %w", err)
+	}
+
+	kindBinaryCtr := m.build(kindCtr)
 	fixturesDir := m.Src.Directory("test/fixtures")
 
 	kindBinFixCtr, err := ApplyFixtures(ctx, kindBinaryCtr, fixturesDir, true)
 	if err != nil {
-		return "", fmt.Errorf("failed to apply fixtures: %w", err)
+		return nil, fmt.Errorf("failed to apply fixtures: %w", err)
 	}
 
+	return kindBinFixCtr, nil
+}
+
+func (m *Dagger) kindContainer(
+	ctx context.Context,
+	dockerSocket *dagger.Socket,
+	kindSvc *dagger.Service,
+	kubeconfig *dagger.Directory,
+) (*dagger.Container, error) {
+	if kubeconfig != nil {
+		return m.KindFromService(ctx, kindSvc, kubeconfig)
+	}
+
+	return m.KindFromModule(dockerSocket, kindSvc), nil
+}
+
+func (m *Dagger) test(ctx context.Context, kindCtr *dagger.Container) (string, error) {
 	// Generate D2 outputs from real cluster
-	basicOutput, err := m.runK8sD2(ctx, kindBinFixCtr, false)
+	basicOutput, err := m.runK8sD2(ctx, kindCtr, false)
 	if err != nil {
 		return "", fmt.Errorf("k8s-d2 execution failed (basic): %w", err)
 	}
 
-	storageOutput, err := m.runK8sD2(ctx, kindBinFixCtr, true)
+	storageOutput, err := m.runK8sD2(ctx, kindCtr, true)
 	if err != nil {
 		return "", fmt.Errorf("k8s-d2 execution failed (storage): %w", err)
 	}
 
-	quietOutput, err := m.runK8sD2Quiet(ctx, kindBinFixCtr, false)
+	quietOutput, err := m.runK8sD2Quiet(ctx, kindCtr, false)
 	if err != nil {
 		return "", fmt.Errorf("k8s-d2 execution failed (quiet mode): %w", err)
 	}
@@ -142,17 +199,8 @@ func (m *Dagger) runK8sD2(
 
 	includeStorage bool,
 ) (string, error) {
-	ctr = ctr.
-		WithExec([]string{"mkdir", "-p", "/output"}).
-		WithWorkdir("/output")
-
-	outputFile := "/output/test.d2"
-	args := []string{"k8sdd", "diagram", "-n", "k8s-d2-test", "-o", outputFile}
-	if includeStorage {
-		args = []string{"k8sdd", "diagram", "-n", "k8s-d2-test", "--include-storage", "-o", outputFile}
-	}
-
-	file := ctr.WithExec(args).File(outputFile)
+	ctr = withOutputDir(ctr)
+	file := ctr.WithExec(k8sddcmd.DiagramArgs(fixtureNamespace, basicOutputFile, includeStorage, false)).File(basicOutputFile)
 
 	output, err := file.Contents(ctx)
 	if err != nil {
@@ -171,24 +219,14 @@ func (m *Dagger) runK8sD2Quiet(
 
 	includeStorage bool,
 ) (string, error) {
-	ctr = ctr.
-		WithExec([]string{"mkdir", "-p", "/output"}).
-		WithWorkdir("/output")
+	ctr = withOutputDir(ctr)
 
-	outputFile := "/output/test-quiet.d2"
-	stdoutFile := "/output/stdout.log"
-	stderrFile := "/output/stderr.log"
-	args := []string{"sh", "-c"}
+	stdoutFile := outputDir + "/stdout.log"
+	stderrFile := outputDir + "/stderr.log"
+	args := append(k8sddcmd.DiagramArgs(fixtureNamespace, quietOutputFile, includeStorage, false), "--quiet")
+	cmd := fmt.Sprintf("%s > %s 2> %s", strings.Join(args, " "), stdoutFile, stderrFile)
 
-	var cmd string
-	if includeStorage {
-		cmd = fmt.Sprintf("k8sdd diagram -n k8s-d2-test --include-storage -o %s --quiet > %s 2> %s", outputFile, stdoutFile, stderrFile)
-	} else {
-		cmd = fmt.Sprintf("k8sdd diagram -n k8s-d2-test -o %s --quiet > %s 2> %s", outputFile, stdoutFile, stderrFile)
-	}
-	args = append(args, cmd)
-
-	execCtr := ctr.WithExec(args)
+	execCtr := ctr.WithExec([]string{"sh", "-c", cmd})
 
 	// Check stdout for unwanted output.
 	stdout, err := execCtr.File(stdoutFile).Contents(ctx)
@@ -201,10 +239,26 @@ func (m *Dagger) runK8sD2Quiet(
 	}
 
 	// Get the D2 output
-	output, err := execCtr.File(outputFile).Contents(ctx)
+	output, err := execCtr.File(quietOutputFile).Contents(ctx)
 	if err != nil {
 		return "", err
 	}
 
 	return output, nil
+}
+
+// runK8sD2Image executes k8sdd against the cluster and returns the SVG artifact.
+func (m *Dagger) runK8sD2Image(
+	ctr *dagger.Container,
+	includeStorage bool,
+) *dagger.File {
+	ctr = withOutputDir(ctr)
+
+	return ctr.WithExec(k8sddcmd.DiagramArgs(fixtureNamespace, imageOutputFile, includeStorage, true)).File(imageOutputFile)
+}
+
+func withOutputDir(ctr *dagger.Container) *dagger.Container {
+	return ctr.
+		WithExec([]string{"mkdir", "-p", outputDir}).
+		WithWorkdir(outputDir)
 }

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -112,7 +112,7 @@ func (m *Dagger) fixtureCluster(
 	kindBinaryCtr := m.build(kindCtr)
 	fixturesDir := m.Src.Directory("test/fixtures")
 
-	kindBinFixCtr, err := ApplyFixtures(ctx, kindBinaryCtr, fixturesDir, true, reuseNamespace)
+	kindBinFixCtr, err := ApplyFixtures(ctx, kindBinaryCtr, fixturesDir, fixtureNamespace, true, reuseNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply fixtures: %w", err)
 	}

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -19,6 +19,8 @@ const (
 	basicOutputFile  = outputDir + "/test.d2"
 	quietOutputFile  = outputDir + "/test-quiet.d2"
 	imageOutputFile  = outputDir + "/test.svg"
+	goModCacheDir    = "/go/pkg/mod"
+	goBuildCacheDir  = "/root/.cache/go-build"
 )
 
 type Dagger struct {
@@ -50,8 +52,12 @@ func (m *Dagger) Run(
 	// Example: `$HOME/.kube`
 	// +optional
 	kubeconfig *dagger.Directory,
+
+	// Reuse the existing fixture namespace instead of deleting it first.
+	// +optional
+	reuseNamespace bool,
 ) (string, error) {
-	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig)
+	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig, reuseNamespace)
 	if err != nil {
 		return "", err
 	}
@@ -75,11 +81,15 @@ func (m *Dagger) FixtureImage(
 	// +optional
 	kubeconfig *dagger.Directory,
 
+	// Reuse the existing fixture namespace instead of deleting it first.
+	// +optional
+	reuseNamespace bool,
+
 	// Include the storage layer in the generated diagram.
 	// +optional
 	includeStorage bool,
 ) (*dagger.File, error) {
-	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig)
+	kindCtr, err := m.fixtureCluster(ctx, dockerSocket, kindSvc, kubeconfig, reuseNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +102,7 @@ func (m *Dagger) fixtureCluster(
 	dockerSocket *dagger.Socket,
 	kindSvc *dagger.Service,
 	kubeconfig *dagger.Directory,
+	reuseNamespace bool,
 ) (*dagger.Container, error) {
 	kindCtr, err := m.kindContainer(ctx, dockerSocket, kindSvc, kubeconfig)
 	if err != nil {
@@ -101,7 +112,7 @@ func (m *Dagger) fixtureCluster(
 	kindBinaryCtr := m.build(kindCtr)
 	fixturesDir := m.Src.Directory("test/fixtures")
 
-	kindBinFixCtr, err := ApplyFixtures(ctx, kindBinaryCtr, fixturesDir, true)
+	kindBinFixCtr, err := ApplyFixtures(ctx, kindBinaryCtr, fixturesDir, true, reuseNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply fixtures: %w", err)
 	}
@@ -153,8 +164,10 @@ func (m *Dagger) BaseContainer() *dagger.Container {
 		From("golang:1.24").
 		WithDirectory("/src", m.Src).
 		WithWorkdir("/src").
-		WithMountedCache("/go/pkg/mod", dag.CacheVolume("go-mod")).
-		WithMountedCache("/root/.cache/go-build", dag.CacheVolume("go-build"))
+		WithEnvVariable("GOMODCACHE", goModCacheDir).
+		WithEnvVariable("GOCACHE", goBuildCacheDir).
+		WithMountedCache(goModCacheDir, dag.CacheVolume("go-mod")).
+		WithMountedCache(goBuildCacheDir, dag.CacheVolume("go-build"))
 }
 
 // runValidationTests runs Go tests to validate D2 outputs


### PR DESCRIPTION
## Summary
- add a `fixture-image` Dagger function that exports the SVG generated from the fixture-backed kind cluster while keeping the existing validation flow intact
- add module-local docs and `just` recipes for creating the local kind cluster, validating the module, and exporting images with hardcoded local defaults
- add Dagger module guidance in `dagger/AGENTS.md` and refresh generated module metadata for the current engine version