### PR TITLE
feat: use automatic D2 layout for namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A command-line tool that generates [D2](https://d2lang.com/) diagram files from 
 - Map service-to-workload relationships
 - Filter by namespace or view entire cluster
 - Track ConfigMaps and Secrets per namespace
-- Customizable grid layout for namespace organization
+- Use D2 automatic layout for cleaner topology diagrams
 - Output to file or stdout for pipeline integration
 - Generate SVG images directly via [Kroki](https://kroki.io/) API (no local D2 installation required)
 
@@ -111,15 +111,11 @@ k8sdd diagram --all-namespaces -o full-cluster.d2
 k8sdd diagram --kubeconfig ~/.kube/prod-config -o prod.d2
 ```
 
-### Layout Options
+### Layout
 
-```bash
-# Control namespace grid layout (default: 3 columns)
-k8sdd diagram --grid-columns 2 -o wide-layout.d2
+Diagrams use D2's automatic layout so namespaces and resources can be positioned without forced grid constraints.
 
-# Single column layout
-k8sdd diagram --grid-columns 1 -o vertical.d2
-```
+> `--grid-columns` is deprecated and has no effect.
 
 ### Advanced Usage
 
@@ -128,7 +124,7 @@ k8sdd diagram --grid-columns 1 -o vertical.d2
 k8sdd diagram --include-storage -o storage.d2
 
 # Combine options
-k8sdd diagram --all-namespaces --include-storage --grid-columns 4 -o complete.d2
+k8sdd diagram --all-namespaces --include-storage -o complete.d2
 
 # Generate SVG with storage layer
 k8sdd diagram --include-storage -i cluster-with-storage.svg
@@ -146,7 +142,6 @@ k8sdd diagram -q -o cluster.d2
 | `--all-namespaces` | `-A` | `false` | Include system namespaces |
 | `--output` | `-o` | stdout | Output D2 file path |
 | `--image` | `-i` | | Output SVG image file (uses Kroki API) |
-| `--grid-columns` | | `3` | Number of columns for namespace layout |
 | `--include-storage` | | `false` | Include PVCs and StorageClasses |
 | `--quiet` | `-q` | `false` | Suppress progress indicators and log messages |
 

--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -30,6 +30,9 @@ func init() {
 	diagramCmd.Flags().StringVarP(&rootOptions.output, "output", "o", "", "output D2 file (default: stdout)")
 	diagramCmd.Flags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
 	diagramCmd.Flags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
-	diagramCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "number of columns in grid layout (0 for single column)")
+	diagramCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
+	if err := diagramCmd.Flags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
+		panic(err)
+	}
 	diagramCmd.Flags().BoolVarP(&rootOptions.quiet, "quiet", "q", false, "suppress progress indicators and log messages")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,10 @@ func init() {
 	rootCmd.Flags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
 	rootCmd.Flags().StringVarP(&rootOptions.output, "output", "o", "", "output file (default: stdout)")
 	rootCmd.Flags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
-	rootCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "number of columns in grid layout (0 for single column)")
+	rootCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
+	if err := rootCmd.Flags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
+		panic(err)
+	}
 	rootCmd.Flags().BoolVarP(&rootOptions.showVersion, "version", "v", false, "show version information")
 	rootCmd.Flags().BoolVarP(&rootOptions.quiet, "quiet", "q", false, "suppress progress indicators and log messages")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import "testing"
+
+func TestGridColumnsFlagIsDeprecated(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{name: "root", flag: rootCmd.Flags().Lookup("grid-columns").Deprecated},
+		{name: "diagram", flag: diagramCmd.Flags().Lookup("grid-columns").Deprecated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.flag == "" {
+				t.Fatalf("expected grid-columns flag to be deprecated")
+			}
+		})
+	}
+}
+
+func TestGridColumnsFlagIsStillAccepted(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  interface{ ParseFlags([]string) error }
+		args []string
+	}{
+		{name: "root", cmd: rootCmd, args: []string{"--grid-columns", "4"}},
+		{name: "diagram", cmd: diagramCmd, args: []string{"--grid-columns", "5"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootOptions.gridColumns = 3
+			if err := tt.cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("expected deprecated grid-columns flag to remain accepted: %v", err)
+			}
+			if rootOptions.gridColumns == 3 {
+				t.Fatalf("expected deprecated grid-columns flag to still parse a value")
+			}
+		})
+	}
+}

--- a/pkg/render/d2.go
+++ b/pkg/render/d2.go
@@ -9,14 +9,15 @@ import (
 )
 
 type D2Renderer struct {
-	w           io.Writer
-	gridColumns int
+	w io.Writer
 }
 
+// NewD2Renderer constructs a D2 renderer.
+// gridColumns is deprecated and ignored; D2 now uses automatic layout.
 func NewD2Renderer(w io.Writer, gridColumns int) *D2Renderer {
+	_ = gridColumns
 	return &D2Renderer{
-		w:           w,
-		gridColumns: gridColumns,
+		w: w,
 	}
 }
 
@@ -37,24 +38,22 @@ direction: right
 		return err
 	}
 
-	if r.gridColumns > 0 {
-		if _, err := fmt.Fprintf(r.w, "namespaces: {\n  grid-columns: %d\n\n", r.gridColumns); err != nil {
+	if len(cluster.Namespaces) == 0 {
+		return nil
+	}
+
+	if _, err := fmt.Fprint(r.w, "namespaces: {\n\n"); err != nil {
+		return err
+	}
+
+	for _, ns := range cluster.Namespaces {
+		if err := r.renderNamespaceIndented(&ns, "  "); err != nil {
 			return err
 		}
-		for _, ns := range cluster.Namespaces {
-			if err := r.renderNamespaceIndented(&ns, "  "); err != nil {
-				return err
-			}
-		}
-		if _, err := fmt.Fprint(r.w, "}\n"); err != nil {
-			return err
-		}
-	} else {
-		for _, ns := range cluster.Namespaces {
-			if err := r.renderNamespaceIndented(&ns, ""); err != nil {
-				return err
-			}
-		}
+	}
+
+	if _, err := fmt.Fprint(r.w, "}\n"); err != nil {
+		return err
 	}
 
 	return nil
@@ -66,7 +65,6 @@ func (r *D2Renderer) renderNamespaceIndented(ns *model.Namespace, indent string)
 
 	fmt.Fprintf(&b, "%s%s: {\n", indent, nsID)
 	fmt.Fprintf(&b, "%s  label: %s\n", indent, ns.Name)
-	fmt.Fprintf(&b, "%s  grid-columns: 3\n", indent)
 	fmt.Fprintf(&b, "%s  style.fill: \"#f0f0f0\"\n\n", indent)
 
 	r.writeAllWorkloads(&b, ns, indent)

--- a/pkg/render/d2_test.go
+++ b/pkg/render/d2_test.go
@@ -110,6 +110,45 @@ func TestRenderLegend_IncludesOnlyRenderedResourceTypes(t *testing.T) {
 	}
 }
 
+func TestRender_IgnoresDeprecatedGridColumns(t *testing.T) {
+	cluster := &model.Cluster{
+		Namespaces: []model.Namespace{
+			{
+				Name: "vars",
+				Deployments: []model.Workload{{
+					Name:     "web",
+					Kind:     "Deployment",
+					Replicas: 1,
+				}},
+			},
+			{
+				Name: "infra",
+				Services: []model.Service{{
+					Name: "metrics",
+					Type: "ClusterIP",
+				}},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	renderer := NewD2Renderer(&buf, 4)
+	if err := renderer.Render(cluster); err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "grid-columns:") {
+		t.Fatalf("expected automatic layout without grid constraints, output was:\n%s", output)
+	}
+	if !strings.Contains(output, "namespaces: {") {
+		t.Fatalf("expected namespaces container in output, output was:\n%s", output)
+	}
+	if !strings.Contains(output, "  vars: {") {
+		t.Fatalf("expected namespace to render inside namespaces container, output was:\n%s", output)
+	}
+}
+
 func renderTestCluster(t *testing.T, cluster *model.Cluster) string {
 	t.Helper()
 


### PR DESCRIPTION
Removes forced namespace grid constraints so D2 can position resources automatically, and deprecates `--grid-columns` as a compatibility no-op.

Closes #45