### PR TITLE
fix: align deprecated root command flags with diagram

### DIFF
--- a/cmd/diagram.go
+++ b/cmd/diagram.go
@@ -23,16 +23,4 @@ func init() {
 		_ = cmd.Help()
 		return err
 	})
-
-	diagramCmd.Flags().StringVar(&rootOptions.kubeconfig, "kubeconfig", "", "path to kubeconfig (default: ~/.kube/config)")
-	diagramCmd.Flags().StringVarP(&rootOptions.namespace, "namespace", "n", "", "namespace to visualize (default: all non-system)")
-	diagramCmd.Flags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
-	diagramCmd.Flags().StringVarP(&rootOptions.output, "output", "o", "", "output D2 file (default: stdout)")
-	diagramCmd.Flags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
-	diagramCmd.Flags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
-	diagramCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
-	if err := diagramCmd.Flags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
-		panic(err)
-	}
-	diagramCmd.Flags().BoolVarP(&rootOptions.quiet, "quiet", "q", false, "suppress progress indicators and log messages")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,17 +42,18 @@ func init() {
 		return err
 	})
 
-	rootCmd.Flags().StringVar(&rootOptions.kubeconfig, "kubeconfig", "", "path to kubeconfig (default: ~/.kube/config)")
-	rootCmd.Flags().StringVarP(&rootOptions.namespace, "namespace", "n", "", "namespace to visualize (default: all non-system)")
-	rootCmd.Flags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
-	rootCmd.Flags().StringVarP(&rootOptions.output, "output", "o", "", "output file (default: stdout)")
-	rootCmd.Flags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
-	rootCmd.Flags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
-	if err := rootCmd.Flags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
+	rootCmd.PersistentFlags().StringVar(&rootOptions.kubeconfig, "kubeconfig", "", "path to kubeconfig (default: ~/.kube/config)")
+	rootCmd.PersistentFlags().StringVarP(&rootOptions.namespace, "namespace", "n", "", "namespace to visualize (default: all non-system)")
+	rootCmd.PersistentFlags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
+	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", "", "output D2 file (default: stdout)")
+	rootCmd.PersistentFlags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
+	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
+	rootCmd.PersistentFlags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
+	if err := rootCmd.PersistentFlags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
 		panic(err)
 	}
 	rootCmd.Flags().BoolVarP(&rootOptions.showVersion, "version", "v", false, "show version information")
-	rootCmd.Flags().BoolVarP(&rootOptions.quiet, "quiet", "q", false, "suppress progress indicators and log messages")
+	rootCmd.PersistentFlags().BoolVarP(&rootOptions.quiet, "quiet", "q", false, "suppress progress indicators and log messages")
 }
 
 func Execute(version string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,13 +2,51 @@ package cmd
 
 import "testing"
 
+func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		shorthand string
+	}{
+		{name: "kubeconfig"},
+		{name: "namespace", shorthand: "n"},
+		{name: "all-namespaces", shorthand: "A"},
+		{name: "output", shorthand: "o"},
+		{name: "image", shorthand: "i"},
+		{name: "include-storage"},
+		{name: "grid-columns"},
+		{name: "quiet", shorthand: "q"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootFlag := rootCmd.Flag(tt.name)
+			if rootFlag == nil {
+				t.Fatalf("expected root command to expose %q", tt.name)
+			}
+
+			diagramFlag := diagramCmd.Flag(tt.name)
+			if diagramFlag == nil {
+				t.Fatalf("expected diagram command to expose %q", tt.name)
+			}
+
+			if rootFlag.Shorthand != tt.shorthand {
+				t.Fatalf("expected root command %q shorthand %q, got %q", tt.name, tt.shorthand, rootFlag.Shorthand)
+			}
+
+			if diagramFlag.Shorthand != tt.shorthand {
+				t.Fatalf("expected diagram command %q shorthand %q, got %q", tt.name, tt.shorthand, diagramFlag.Shorthand)
+			}
+		})
+	}
+}
+
 func TestGridColumnsFlagIsDeprecated(t *testing.T) {
 	tests := []struct {
 		name string
 		flag string
 	}{
-		{name: "root", flag: rootCmd.Flags().Lookup("grid-columns").Deprecated},
-		{name: "diagram", flag: diagramCmd.Flags().Lookup("grid-columns").Deprecated},
+		{name: "root", flag: rootCmd.Flag("grid-columns").Deprecated},
+		{name: "diagram", flag: diagramCmd.Flag("grid-columns").Deprecated},
 	}
 
 	for _, tt := range tests {
@@ -38,6 +76,30 @@ func TestGridColumnsFlagIsStillAccepted(t *testing.T) {
 			}
 			if rootOptions.gridColumns == 3 {
 				t.Fatalf("expected deprecated grid-columns flag to still parse a value")
+			}
+		})
+	}
+}
+
+func TestImageFlagIsAcceptedOnRootAndDiagram(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  interface{ ParseFlags([]string) error }
+		args []string
+		want string
+	}{
+		{name: "root", cmd: rootCmd, args: []string{"-i", "root.svg"}, want: "root.svg"},
+		{name: "diagram", cmd: diagramCmd, args: []string{"-i", "diagram.svg"}, want: "diagram.svg"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootOptions.image = ""
+			if err := tt.cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("expected image flag to parse: %v", err)
+			}
+			if rootOptions.image != tt.want {
+				t.Fatalf("expected image flag to set %q, got %q", tt.want, rootOptions.image)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- align the deprecated root command generation flags with `k8sdd diagram`
- keep bare `k8sdd` working during the deprecation period

Closes #58