### PR TITLE
fix: include default namespace and validate namespace selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ k8sdd diagram -i cluster.svg
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--kubeconfig` | | `~/.kube/config` | Path to kubeconfig file |
-| `--namespace` | `-n` | | Filter by specific namespace |
+| `--namespace` | `-n` | | Filter by specific namespaces (repeat or comma-separated) |
 | `--all-namespaces` | `-A` | `false` | Include system namespaces |
 | `--output` | `-o` | stdout | Output D2 file path |
 | `--image` | `-i` | | Output SVG image file (uses Kroki API) |

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -51,7 +51,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := kube.FetchOptions{
-		Namespace:      rootOptions.namespace,
+		Namespaces:     rootOptions.namespaces,
 		AllNamespaces:  rootOptions.allNamespaces,
 		IncludeStorage: rootOptions.includeStorage,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 
 type RootOptions struct {
 	kubeconfig     string
-	namespace      string
+	namespaces     []string
 	allNamespaces  bool
 	output         string
 	image          string
@@ -43,7 +43,7 @@ func init() {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&rootOptions.kubeconfig, "kubeconfig", "", "path to kubeconfig (default: ~/.kube/config)")
-	rootCmd.PersistentFlags().StringVarP(&rootOptions.namespace, "namespace", "n", "", "namespace to visualize (default: all non-system)")
+	rootCmd.PersistentFlags().StringSliceVarP(&rootOptions.namespaces, "namespace", "n", nil, "namespaces to visualize (repeat or comma-separated; default: all non-system)")
 	rootCmd.PersistentFlags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", "", "output D2 file (default: stdout)")
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
 
 func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
 	tests := []struct {
@@ -100,6 +104,28 @@ func TestImageFlagIsAcceptedOnRootAndDiagram(t *testing.T) {
 			}
 			if rootOptions.image != tt.want {
 				t.Fatalf("expected image flag to set %q, got %q", tt.want, rootOptions.image)
+			}
+		})
+	}
+}
+
+func TestNamespaceFlagSupportsMultipleValues(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  interface{ Flags() *pflag.FlagSet }
+	}{
+		{name: "root", cmd: rootCmd},
+		{name: "diagram", cmd: diagramCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flag := tt.cmd.Flags().Lookup("namespace")
+			if flag == nil {
+				t.Fatalf("expected namespace flag to be registered")
+			}
+			if got := flag.Value.Type(); got != "stringSlice" {
+				t.Fatalf("expected namespace flag type stringSlice, got %q", got)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/huh/spinner v0.0.0-20251124111010-6575a6e28cb3
 	github.com/charmbracelet/log v0.4.2
 	github.com/spf13/cobra v1.8.0
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v0.29.0
@@ -25,6 +26,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
@@ -50,8 +52,8 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxER
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
 github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
@@ -102,6 +104,8 @@ github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
 github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/justfile
+++ b/justfile
@@ -5,7 +5,6 @@ alias b := build
 alias g := generate
 alias tl := test_local
 
-
 _default:
 	just --list
 
@@ -25,8 +24,7 @@ run *parameters: build
 	./k8sdd {{parameters}}
 
 generate *parameters:
-	just run {{parameters}} -o {{outputFile}}
-	d2 {{outputFile}} {{outputImage}}
+	./k8sdd diagram {{parameters}} -i {{outputImage}}
 	open {{outputImage}}
 
 [working-directory: "dagger"]

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Client struct {
-	clientset *kubernetes.Clientset
+	clientset kubernetes.Interface
 }
 
 func init() {

--- a/pkg/kube/fetch.go
+++ b/pkg/kube/fetch.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/vieitesss/k8s-d2/pkg/model"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type FetchOptions struct {
-	Namespace      string
+	Namespaces     []string
 	AllNamespaces  bool
 	IncludeStorage bool
 }
@@ -40,8 +41,11 @@ func (c *Client) FetchTopology(ctx context.Context, opts FetchOptions) (*model.C
 }
 
 func (c *Client) getNamespaces(ctx context.Context, opts FetchOptions) ([]string, error) {
-	if opts.Namespace != "" {
-		return []string{opts.Namespace}, nil
+	if namespaces := normalizeNamespaceNames(opts.Namespaces); len(namespaces) > 0 {
+		if err := c.validateNamespacesExist(ctx, namespaces); err != nil {
+			return nil, err
+		}
+		return namespaces, nil
 	}
 
 	list, err := c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
@@ -50,6 +54,53 @@ func (c *Client) getNamespaces(ctx context.Context, opts FetchOptions) ([]string
 	}
 
 	return c.filterNamespaceNames(list.Items, opts.AllNamespaces), nil
+}
+
+func (c *Client) validateNamespacesExist(ctx context.Context, names []string) error {
+	var missing []string
+
+	for _, name := range names {
+		_, err := c.clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+		if err == nil {
+			continue
+		}
+		if apierrors.IsNotFound(err) {
+			missing = append(missing, name)
+			continue
+		}
+		if apierrors.IsForbidden(err) {
+			continue
+		}
+		return err
+	}
+
+	if len(missing) == 1 {
+		return fmt.Errorf("namespace not found: %s", missing[0])
+	}
+	if len(missing) > 1 {
+		return fmt.Errorf("namespaces not found: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+func normalizeNamespaceNames(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	var normalized []string
+
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		normalized = append(normalized, name)
+	}
+
+	return normalized
 }
 
 func (c *Client) filterNamespaceNames(items []corev1.Namespace, includeSystemNamespaces bool) []string {
@@ -241,7 +292,7 @@ func (c *Client) fetchPVCs(ctx context.Context, nsName string, ns *model.Namespa
 
 func isSystemNamespace(name string) bool {
 	systemPrefixes := []string{"kube-", "openshift-", "istio-"}
-	systemNames := []string{"default", "kube-system", "kube-public", "kube-node-lease", "local-path-storage"}
+	systemNames := []string{"kube-system", "kube-public", "kube-node-lease", "local-path-storage"}
 
 	if slices.Contains(systemNames, name) {
 		return true

--- a/pkg/kube/fetch_test.go
+++ b/pkg/kube/fetch_test.go
@@ -1,0 +1,175 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestIsSystemNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      bool
+	}{
+		{name: "default namespace is user-visible", namespace: "default", want: false},
+		{name: "kube-system exact name", namespace: "kube-system", want: true},
+		{name: "kube-public exact name", namespace: "kube-public", want: true},
+		{name: "kube-node-lease exact name", namespace: "kube-node-lease", want: true},
+		{name: "local-path-storage exact name", namespace: "local-path-storage", want: true},
+		{name: "kube prefix", namespace: "kube-monitoring", want: true},
+		{name: "openshift prefix", namespace: "openshift-monitoring", want: true},
+		{name: "istio prefix", namespace: "istio-system", want: true},
+		{name: "regular namespace", namespace: "team-a", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSystemNamespace(tt.namespace); got != tt.want {
+				t.Fatalf("isSystemNamespace(%q) = %t, want %t", tt.namespace, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterNamespaceNames(t *testing.T) {
+	items := []corev1.Namespace{
+		{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "openshift-monitoring"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "istio-system"}},
+	}
+
+	client := &Client{}
+
+	t.Run("default view excludes only system namespaces", func(t *testing.T) {
+		got := client.filterNamespaceNames(items, false)
+		want := []string{"default", "team-a"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("filterNamespaceNames(..., false) = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("all namespaces view keeps every namespace", func(t *testing.T) {
+		got := client.filterNamespaceNames(items, true)
+		want := []string{"default", "team-a", "kube-system", "openshift-monitoring", "istio-system"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("filterNamespaceNames(..., true) = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestNormalizeNamespaceNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "keeps explicit order",
+			input: []string{"apps", "default", "observability"},
+			want:  []string{"apps", "default", "observability"},
+		},
+		{
+			name:  "trims whitespace and removes empty values",
+			input: []string{" apps ", "", " default", "   "},
+			want:  []string{"apps", "default"},
+		},
+		{
+			name:  "deduplicates repeated namespaces",
+			input: []string{"apps", "default", "apps", "default", "infra"},
+			want:  []string{"apps", "default", "infra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeNamespaceNames(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("normalizeNamespaceNames(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetNamespacesUsesExplicitNamespaces(t *testing.T) {
+	client := &Client{clientset: fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "observability"}},
+	)}
+
+	got, err := client.getNamespaces(context.Background(), FetchOptions{
+		Namespaces: []string{" apps ", "default", "apps", "observability"},
+	})
+	if err != nil {
+		t.Fatalf("getNamespaces returned error: %v", err)
+	}
+
+	want := []string{"apps", "default", "observability"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("getNamespaces returned %v, want %v", got, want)
+	}
+}
+
+func TestGetNamespacesFailsForMissingExplicitNamespace(t *testing.T) {
+	client := &Client{clientset: fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "apps"}},
+	)}
+
+	_, err := client.getNamespaces(context.Background(), FetchOptions{
+		Namespaces: []string{"default", "missing", "apps"},
+	})
+	if err == nil {
+		t.Fatalf("expected missing explicit namespace to return an error")
+	}
+	if !strings.Contains(err.Error(), "namespace not found") || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected missing namespace error, got %v", err)
+	}
+}
+
+func TestGetNamespacesAllowsForbiddenNamespaceValidation(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+	)
+	clientset.PrependReactor("get", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction, ok := action.(k8stesting.GetAction)
+		if !ok || getAction.GetName() != "restricted" {
+			return false, nil, nil
+		}
+
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "namespaces"},
+			"restricted",
+			errors.New("forbidden"),
+		)
+	})
+
+	client := &Client{clientset: clientset}
+
+	got, err := client.getNamespaces(context.Background(), FetchOptions{
+		Namespaces: []string{"default", "restricted"},
+	})
+	if err != nil {
+		t.Fatalf("expected forbidden namespace validation to be tolerated, got %v", err)
+	}
+
+	want := []string{"default", "restricted"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("getNamespaces returned %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- include the default namespace in the default topology output
- support repeated and comma-separated --namespace values and fail early for missing explicit namespaces
- keep the justfile generic run recipe while updating generate to use direct SVG output

Closes #54