### PR TITLE
feat: configure Kroki endpoint and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Or generate an SVG directly (no D2 installation required):
 k8sdd diagram -i cluster.svg
 ```
 
+By default, SVG generation uses `https://kroki.io` with a `30s` timeout.
+
+Use a private or self-hosted Kroki deployment when needed:
+
+```bash
+k8sdd diagram -i cluster.svg --kroki-base-url https://kroki.internal --kroki-timeout 60s
+```
+
 ## Flags
 
 | Flag | Short | Default | Description |
@@ -87,10 +95,14 @@ k8sdd diagram -i cluster.svg
 | `--all-namespaces` | `-A` | `false` | Include system namespaces |
 | `--output` | `-o` | stdout | Output D2 file path |
 | `--image` | `-i` | | Output SVG image file (uses Kroki API) |
+| `--kroki-base-url` | | `https://kroki.io` | Kroki base URL for SVG generation |
+| `--kroki-timeout` | | `30s` | Kroki request timeout for SVG generation |
 | `--include-storage` | | `false` | Include PVCs and StorageClasses |
 | `--quiet` | `-q` | `false` | Suppress progress indicators and log messages |
 
 > **Note:** `--output` and `--image` are mutually exclusive.
+>
+> `--kroki-base-url` and `--kroki-timeout` are only used with `--image`. When set, the Kroki base URL must not be empty and the timeout must be greater than `0`.
 
 ## Requirements
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -89,7 +89,8 @@ func validateImageOptions() error {
 		return nil
 	}
 
-	if strings.TrimSpace(rootOptions.krokiBaseURL) == "" {
+	rootOptions.krokiBaseURL = strings.TrimSpace(rootOptions.krokiBaseURL)
+	if rootOptions.krokiBaseURL == "" {
 		return errors.New("flag --kroki-base-url cannot be empty when using --image")
 	}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -45,6 +45,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return errors.New("flags --output/-o and --image/-i are mutually exclusive")
 	}
 
+	if err := validateImageOptions(); err != nil {
+		return err
+	}
+
 	client, err := createClientWithSpinner()
 	if err != nil {
 		return err
@@ -77,6 +81,22 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	log.Info("D2 diagram generated successfully")
+	return nil
+}
+
+func validateImageOptions() error {
+	if rootOptions.image == "" {
+		return nil
+	}
+
+	if strings.TrimSpace(rootOptions.krokiBaseURL) == "" {
+		return errors.New("flag --kroki-base-url cannot be empty when using --image")
+	}
+
+	if rootOptions.krokiTimeout <= 0 {
+		return errors.New("flag --kroki-timeout must be greater than 0 when using --image")
+	}
+
 	return nil
 }
 
@@ -142,7 +162,10 @@ func generateImage(cluster *model.Cluster) error {
 
 	// Send to Kroki
 	var svgData []byte
-	krokiClient := kroki.NewClient()
+	krokiClient := kroki.NewClientWithOptions(kroki.Options{
+		BaseURL: rootOptions.krokiBaseURL,
+		Timeout: rootOptions.krokiTimeout,
+	})
 
 	if err := runWithSpinner("Generating SVG via Kroki...", func() error {
 		var krokiErr error

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vieitesss/k8s-d2/pkg/model"
+)
+
+func TestValidateImageOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options RootOptions
+		wantErr string
+	}{
+		{
+			name: "non-image output skips Kroki validation",
+			options: RootOptions{
+				output:       "cluster.d2",
+				krokiTimeout: -1 * time.Second,
+			},
+		},
+		{
+			name: "blank base URL is rejected for image generation",
+			options: RootOptions{
+				image:        "cluster.svg",
+				krokiBaseURL: "   ",
+				krokiTimeout: time.Second,
+			},
+			wantErr: "flag --kroki-base-url cannot be empty when using --image",
+		},
+		{
+			name: "non-positive timeout is rejected for image generation",
+			options: RootOptions{
+				image:        "cluster.svg",
+				krokiBaseURL: "https://kroki.internal",
+				krokiTimeout: 0,
+			},
+			wantErr: "flag --kroki-timeout must be greater than 0 when using --image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalOptions := rootOptions
+			rootOptions = tt.options
+			t.Cleanup(func() {
+				rootOptions = originalOptions
+			})
+
+			err := validateImageOptions()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+
+			if err.Error() != tt.wantErr {
+				t.Fatalf("expected error %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestGenerateImageUsesConfiguredKrokiBaseURL(t *testing.T) {
+	requestedPath := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST request, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "text/plain" {
+			t.Errorf("expected Content-Type text/plain, got %s", ct)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`))
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	outputFile := filepath.Join(tempDir, "cluster")
+
+	originalOptions := rootOptions
+	t.Cleanup(func() {
+		rootOptions = originalOptions
+	})
+
+	rootOptions.image = outputFile
+	rootOptions.krokiBaseURL = server.URL + "/"
+	rootOptions.krokiTimeout = time.Second
+	rootOptions.quiet = true
+
+	cluster := &model.Cluster{
+		Name: "test-cluster",
+		Namespaces: []model.Namespace{{
+			Name: "default",
+		}},
+	}
+
+	if err := generateImage(cluster); err != nil {
+		t.Fatalf("generateImage returned error: %v", err)
+	}
+
+	if requestedPath != "/d2/svg" {
+		t.Fatalf("expected request path /d2/svg, got %q", requestedPath)
+	}
+
+	svgPath := outputFile + ".svg"
+	content, err := os.ReadFile(svgPath)
+	if err != nil {
+		t.Fatalf("expected SVG file %q to be written: %v", svgPath, err)
+	}
+
+	if !strings.Contains(string(content), "<svg") {
+		t.Fatalf("expected written file to contain SVG markup, got %q", string(content))
+	}
+}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -35,6 +35,14 @@ func TestValidateImageOptions(t *testing.T) {
 			wantErr: "flag --kroki-base-url cannot be empty when using --image",
 		},
 		{
+			name: "base URL is trimmed before use",
+			options: RootOptions{
+				image:        "cluster.svg",
+				krokiBaseURL: "  https://kroki.internal  ",
+				krokiTimeout: time.Second,
+			},
+		},
+		{
 			name: "non-positive timeout is rejected for image generation",
 			options: RootOptions{
 				image:        "cluster.svg",
@@ -57,6 +65,9 @@ func TestValidateImageOptions(t *testing.T) {
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("expected no error, got %v", err)
+				}
+				if tt.options.image != "" && strings.TrimSpace(tt.options.krokiBaseURL) != "" && rootOptions.krokiBaseURL != strings.TrimSpace(tt.options.krokiBaseURL) {
+					t.Fatalf("expected Kroki base URL to be trimmed to %q, got %q", strings.TrimSpace(tt.options.krokiBaseURL), rootOptions.krokiBaseURL)
 				}
 				return
 			}
@@ -97,7 +108,7 @@ func TestGenerateImageUsesConfiguredKrokiBaseURL(t *testing.T) {
 	})
 
 	rootOptions.image = outputFile
-	rootOptions.krokiBaseURL = server.URL + "/"
+	rootOptions.krokiBaseURL = "  " + server.URL + "/  "
 	rootOptions.krokiTimeout = time.Second
 	rootOptions.quiet = true
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
+	"github.com/vieitesss/k8s-d2/pkg/kroki"
 )
 
 type RootOptions struct {
@@ -11,6 +14,8 @@ type RootOptions struct {
 	allNamespaces  bool
 	output         string
 	image          string
+	krokiBaseURL   string
+	krokiTimeout   time.Duration
 	includeStorage bool
 	gridColumns    int
 	showVersion    bool
@@ -47,6 +52,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&rootOptions.allNamespaces, "all-namespaces", "A", false, "include all namespaces (including system)")
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.output, "output", "o", "", "output D2 file (default: stdout)")
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
+	rootCmd.PersistentFlags().StringVar(&rootOptions.krokiBaseURL, "kroki-base-url", kroki.DefaultBaseURL, "Kroki base URL for SVG generation")
+	rootCmd.PersistentFlags().DurationVar(&rootOptions.krokiTimeout, "kroki-timeout", kroki.DefaultTimeout, "Kroki request timeout for SVG generation")
 	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
 	rootCmd.PersistentFlags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
 	if err := rootCmd.PersistentFlags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
+	"github.com/vieitesss/k8s-d2/pkg/kroki"
 )
 
 func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
@@ -16,6 +18,8 @@ func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
 		{name: "all-namespaces", shorthand: "A"},
 		{name: "output", shorthand: "o"},
 		{name: "image", shorthand: "i"},
+		{name: "kroki-base-url"},
+		{name: "kroki-timeout"},
 		{name: "include-storage"},
 		{name: "grid-columns"},
 		{name: "quiet", shorthand: "q"},
@@ -104,6 +108,50 @@ func TestImageFlagIsAcceptedOnRootAndDiagram(t *testing.T) {
 			}
 			if rootOptions.image != tt.want {
 				t.Fatalf("expected image flag to set %q, got %q", tt.want, rootOptions.image)
+			}
+		})
+	}
+}
+
+func TestKrokiFlagsAreAcceptedOnRootAndDiagram(t *testing.T) {
+	tests := []struct {
+		name        string
+		cmd         interface{ ParseFlags([]string) error }
+		args        []string
+		wantBaseURL string
+		wantTimeout time.Duration
+	}{
+		{
+			name:        "root",
+			cmd:         rootCmd,
+			args:        []string{"--kroki-base-url", "https://kroki.internal", "--kroki-timeout", "45s"},
+			wantBaseURL: "https://kroki.internal",
+			wantTimeout: 45 * time.Second,
+		},
+		{
+			name:        "diagram",
+			cmd:         diagramCmd,
+			args:        []string{"--kroki-base-url", "https://kroki.example.com/api", "--kroki-timeout", "2m"},
+			wantBaseURL: "https://kroki.example.com/api",
+			wantTimeout: 2 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootOptions.krokiBaseURL = kroki.DefaultBaseURL
+			rootOptions.krokiTimeout = kroki.DefaultTimeout
+
+			if err := tt.cmd.ParseFlags(tt.args); err != nil {
+				t.Fatalf("expected Kroki flags to parse: %v", err)
+			}
+
+			if rootOptions.krokiBaseURL != tt.wantBaseURL {
+				t.Fatalf("expected Kroki base URL %q, got %q", tt.wantBaseURL, rootOptions.krokiBaseURL)
+			}
+
+			if rootOptions.krokiTimeout != tt.wantTimeout {
+				t.Fatalf("expected Kroki timeout %s, got %s", tt.wantTimeout, rootOptions.krokiTimeout)
 			}
 		})
 	}

--- a/pkg/kroki/client.go
+++ b/pkg/kroki/client.go
@@ -5,13 +5,20 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
 const (
-	defaultBaseURL = "https://kroki.io"
-	defaultTimeout = 30 * time.Second
+	DefaultBaseURL = "https://kroki.io"
+	DefaultTimeout = 30 * time.Second
 )
+
+// Options configures the Kroki client.
+type Options struct {
+	BaseURL string
+	Timeout time.Duration
+}
 
 // Client handles communication with the Kroki API.
 type Client struct {
@@ -21,10 +28,25 @@ type Client struct {
 
 // NewClient creates a new Kroki client with default settings.
 func NewClient() *Client {
+	return NewClientWithOptions(Options{})
+}
+
+// NewClientWithOptions creates a new Kroki client with explicit configuration.
+func NewClientWithOptions(opts Options) *Client {
+	baseURL := opts.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
 	return &Client{
-		baseURL: defaultBaseURL,
+		baseURL: strings.TrimRight(baseURL, "/"),
 		httpClient: &http.Client{
-			Timeout: defaultTimeout,
+			Timeout: timeout,
 		},
 	}
 }

--- a/pkg/kroki/client.go
+++ b/pkg/kroki/client.go
@@ -33,7 +33,7 @@ func NewClient() *Client {
 
 // NewClientWithOptions creates a new Kroki client with explicit configuration.
 func NewClientWithOptions(opts Options) *Client {
-	baseURL := opts.BaseURL
+	baseURL := strings.TrimSpace(opts.BaseURL)
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}

--- a/pkg/kroki/client_test.go
+++ b/pkg/kroki/client_test.go
@@ -21,7 +21,7 @@ func TestNewClientDefaults(t *testing.T) {
 
 func TestNewClientUsesConfiguredBaseURLAndTimeout(t *testing.T) {
 	client := NewClientWithOptions(Options{
-		BaseURL: "https://kroki.internal/",
+		BaseURL: "  https://kroki.internal/  ",
 		Timeout: 45 * time.Second,
 	})
 

--- a/pkg/kroki/client_test.go
+++ b/pkg/kroki/client_test.go
@@ -4,7 +4,35 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
+
+func TestNewClientDefaults(t *testing.T) {
+	client := NewClient()
+
+	if client.baseURL != DefaultBaseURL {
+		t.Fatalf("expected default base URL %q, got %q", DefaultBaseURL, client.baseURL)
+	}
+
+	if client.httpClient.Timeout != DefaultTimeout {
+		t.Fatalf("expected default timeout %s, got %s", DefaultTimeout, client.httpClient.Timeout)
+	}
+}
+
+func TestNewClientUsesConfiguredBaseURLAndTimeout(t *testing.T) {
+	client := NewClientWithOptions(Options{
+		BaseURL: "https://kroki.internal/",
+		Timeout: 45 * time.Second,
+	})
+
+	if client.baseURL != "https://kroki.internal" {
+		t.Fatalf("expected normalized base URL %q, got %q", "https://kroki.internal", client.baseURL)
+	}
+
+	if client.httpClient.Timeout != 45*time.Second {
+		t.Fatalf("expected timeout %s, got %s", 45*time.Second, client.httpClient.Timeout)
+	}
+}
 
 func TestGenerateSVG_Success(t *testing.T) {
 	mockSVG := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`)
@@ -25,10 +53,7 @@ func TestGenerateSVG_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{
-		baseURL:    server.URL,
-		httpClient: server.Client(),
-	}
+	client := NewClientWithOptions(Options{BaseURL: server.URL + "/", Timeout: time.Second})
 
 	result, err := client.GenerateSVG("a -> b")
 	if err != nil {
@@ -51,10 +76,7 @@ func TestGenerateSVG_NonOKStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{
-		baseURL:    server.URL,
-		httpClient: server.Client(),
-	}
+	client := NewClientWithOptions(Options{BaseURL: server.URL, Timeout: time.Second})
 
 	_, err := client.GenerateSVG("invalid diagram")
 	if err == nil {
@@ -69,10 +91,7 @@ func TestGenerateSVG_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{
-		baseURL:    server.URL,
-		httpClient: server.Client(),
-	}
+	client := NewClientWithOptions(Options{BaseURL: server.URL, Timeout: time.Second})
 
 	_, err := client.GenerateSVG("a -> b")
 	if err == nil {


### PR DESCRIPTION
## Summary
- add configurable Kroki base URL and timeout flags for SVG generation
- validate Kroki image settings and cover the new behavior with tests

Closes #56