### PR TITLE
feat: render service ports in D2 service nodes

### DIFF
--- a/internal/validation/parser.go
+++ b/internal/validation/parser.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"bytes"
-	"strconv"
 
 	"github.com/vieitesss/k8s-d2/pkg/kube"
 	"github.com/vieitesss/k8s-d2/pkg/model"
@@ -195,18 +194,10 @@ func (p *FixtureParser) parseService(doc []byte, ns *model.Namespace) error {
 	}
 
 	for _, port := range svc.Spec.Ports {
-		targetPort := port.TargetPort.StrVal
-		if targetPort == "" {
-			if port.TargetPort.IntVal != 0 {
-				targetPort = strconv.FormatInt(int64(port.TargetPort.IntVal), 10)
-			} else {
-				targetPort = strconv.FormatInt(int64(port.Port), 10)
-			}
-		}
 		service.Ports = append(service.Ports, model.Port{
 			Name:       port.Name,
 			Port:       port.Port,
-			TargetPort: targetPort,
+			TargetPort: kube.ServiceTargetPort(port),
 		})
 	}
 

--- a/internal/validation/parser.go
+++ b/internal/validation/parser.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"bytes"
+	"strconv"
 
 	"github.com/vieitesss/k8s-d2/pkg/kube"
 	"github.com/vieitesss/k8s-d2/pkg/model"
@@ -193,11 +194,19 @@ func (p *FixtureParser) parseService(doc []byte, ns *model.Namespace) error {
 		Selector: svc.Spec.Selector,
 	}
 
-	// Add ports if needed in the future
 	for _, port := range svc.Spec.Ports {
+		targetPort := port.TargetPort.StrVal
+		if targetPort == "" {
+			if port.TargetPort.IntVal != 0 {
+				targetPort = strconv.FormatInt(int64(port.TargetPort.IntVal), 10)
+			} else {
+				targetPort = strconv.FormatInt(int64(port.Port), 10)
+			}
+		}
 		service.Ports = append(service.Ports, model.Port{
+			Name:       port.Name,
 			Port:       port.Port,
-			TargetPort: port.TargetPort.IntVal,
+			TargetPort: targetPort,
 		})
 	}
 

--- a/internal/validation/parser_test.go
+++ b/internal/validation/parser_test.go
@@ -1,0 +1,41 @@
+package validation_test
+
+import (
+	"testing"
+
+	"github.com/vieitesss/k8s-d2/internal/validation"
+	"github.com/vieitesss/k8s-d2/pkg/model"
+)
+
+func TestFixtureParser_ParseServicePreservesNamedTargetPort(t *testing.T) {
+	parser := validation.NewFixtureParser("apps")
+	cluster, err := parser.ParseFixtures([][]byte{[]byte(`apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: apps
+spec:
+  type: ClusterIP
+  selector:
+    app: api
+  ports:
+  - name: http
+    port: 80
+    targetPort: web
+  - port: 443
+`)})
+	if err != nil {
+		t.Fatalf("ParseFixtures returned error: %v", err)
+	}
+
+	got := cluster.Namespaces[0].Services[0].Ports
+	want := []model.Port{{Name: "http", Port: 80, TargetPort: "web"}, {Port: 443, TargetPort: "443"}}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ports, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("port %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -4,7 +4,9 @@ import (
 	"flag"
 	"io"
 	"path/filepath"
+	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
@@ -43,4 +45,16 @@ func NewClient(kubeconfigPath string) (*Client, error) {
 	}
 
 	return &Client{clientset: clientset}, nil
+}
+
+// ServiceTargetPort returns the rendered targetPort value, preserving named ports
+// and defaulting omitted targetPort values to the service port itself.
+func ServiceTargetPort(port corev1.ServicePort) string {
+	if port.TargetPort.StrVal != "" {
+		return port.TargetPort.StrVal
+	}
+	if port.TargetPort.IntVal != 0 {
+		return strconv.FormatInt(int64(port.TargetPort.IntVal), 10)
+	}
+	return strconv.FormatInt(int64(port.Port), 10)
 }

--- a/pkg/kube/fetch.go
+++ b/pkg/kube/fetch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/vieitesss/k8s-d2/pkg/model"
@@ -218,10 +219,18 @@ func (c *Client) fetchServices(ctx context.Context, nsName string, ns *model.Nam
 	for _, svc := range svcs.Items {
 		ports := []model.Port{}
 		for _, p := range svc.Spec.Ports {
+			targetPort := p.TargetPort.StrVal
+			if targetPort == "" {
+				if p.TargetPort.IntVal != 0 {
+					targetPort = strconv.FormatInt(int64(p.TargetPort.IntVal), 10)
+				} else {
+					targetPort = strconv.FormatInt(int64(p.Port), 10)
+				}
+			}
 			ports = append(ports, model.Port{
 				Name:       p.Name,
 				Port:       p.Port,
-				TargetPort: p.TargetPort.IntVal,
+				TargetPort: targetPort,
 			})
 		}
 		ns.Services = append(ns.Services, model.Service{

--- a/pkg/kube/fetch.go
+++ b/pkg/kube/fetch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/vieitesss/k8s-d2/pkg/model"
@@ -219,18 +218,10 @@ func (c *Client) fetchServices(ctx context.Context, nsName string, ns *model.Nam
 	for _, svc := range svcs.Items {
 		ports := []model.Port{}
 		for _, p := range svc.Spec.Ports {
-			targetPort := p.TargetPort.StrVal
-			if targetPort == "" {
-				if p.TargetPort.IntVal != 0 {
-					targetPort = strconv.FormatInt(int64(p.TargetPort.IntVal), 10)
-				} else {
-					targetPort = strconv.FormatInt(int64(p.Port), 10)
-				}
-			}
 			ports = append(ports, model.Port{
 				Name:       p.Name,
 				Port:       p.Port,
-				TargetPort: targetPort,
+				TargetPort: ServiceTargetPort(p),
 			})
 		}
 		ns.Services = append(ns.Services, model.Service{

--- a/pkg/kube/fetch_test.go
+++ b/pkg/kube/fetch_test.go
@@ -206,3 +206,23 @@ func TestFetchServicesPreservesNamedTargetPorts(t *testing.T) {
 		t.Fatalf("ports = %+v, want %+v", ns.Services[0].Ports, want)
 	}
 }
+
+func TestServiceTargetPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port corev1.ServicePort
+		want string
+	}{
+		{name: "named target port", port: corev1.ServicePort{Port: 80, TargetPort: intstr.FromString("web")}, want: "web"},
+		{name: "numeric target port", port: corev1.ServicePort{Port: 80, TargetPort: intstr.FromInt32(8080)}, want: "8080"},
+		{name: "omitted target port defaults to service port", port: corev1.ServicePort{Port: 443}, want: "443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ServiceTargetPort(tt.port); got != tt.want {
+				t.Fatalf("ServiceTargetPort(%+v) = %q, want %q", tt.port, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kube/fetch_test.go
+++ b/pkg/kube/fetch_test.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vieitesss/k8s-d2/pkg/model"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
@@ -171,5 +173,36 @@ func TestGetNamespacesAllowsForbiddenNamespaceValidation(t *testing.T) {
 	want := []string{"default", "restricted"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("getNamespaces returned %v, want %v", got, want)
+	}
+}
+
+func TestFetchServicesPreservesNamedTargetPorts(t *testing.T) {
+	client := &Client{clientset: fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "apps"},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{"app": "api"},
+			Ports: []corev1.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromString("web"),
+			}, {
+				Port: 443,
+			}},
+		},
+	})}
+
+	ns := &model.Namespace{Name: "apps"}
+	if err := client.fetchServices(context.Background(), "apps", ns); err != nil {
+		t.Fatalf("fetchServices returned error: %v", err)
+	}
+
+	if len(ns.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(ns.Services))
+	}
+
+	want := []model.Port{{Name: "http", Port: 80, TargetPort: "web"}, {Port: 443, TargetPort: "443"}}
+	if !reflect.DeepEqual(ns.Services[0].Ports, want) {
+		t.Fatalf("ports = %+v, want %+v", ns.Services[0].Ports, want)
 	}
 }

--- a/pkg/model/format.go
+++ b/pkg/model/format.go
@@ -19,3 +19,26 @@ func FormatMountLabel(mounts []VolumeMount) string {
 	}
 	return strings.Join(labels, "\n")
 }
+
+// FormatServicePortLabel creates a compact label for a single service port.
+// Examples: "80", "http: 80 -> web", "metrics: 9090 -> 9091".
+func FormatServicePortLabel(port Port) string {
+	portValue := fmt.Sprintf("%d", port.Port)
+	label := portValue
+	if port.Name != "" {
+		label = fmt.Sprintf("%s: %s", port.Name, portValue)
+	}
+	if port.TargetPort != "" && port.TargetPort != portValue {
+		label = fmt.Sprintf("%s -> %s", label, port.TargetPort)
+	}
+	return label
+}
+
+// FormatServicePortsLabel joins multiple service ports in render order.
+func FormatServicePortsLabel(ports []Port) string {
+	labels := make([]string, len(ports))
+	for i, port := range ports {
+		labels[i] = FormatServicePortLabel(port)
+	}
+	return strings.Join(labels, "\n")
+}

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -42,7 +42,7 @@ type Service struct {
 type Port struct {
 	Name       string
 	Port       int32
-	TargetPort int32
+	TargetPort string // Numeric or named Kubernetes targetPort value.
 }
 
 type PVC struct {

--- a/pkg/render/d2.go
+++ b/pkg/render/d2.go
@@ -188,9 +188,13 @@ func (r *D2Renderer) writeWorkload(b *strings.Builder, w *model.Workload, indent
 
 func (r *D2Renderer) writeService(b *strings.Builder, svc *model.Service, indent string) {
 	svcID := ServiceID(svc.Name)
+	label := fmt.Sprintf("⎈ %s\n%s", svc.Name, svc.Type)
+	if len(svc.Ports) > 0 {
+		label = fmt.Sprintf("%s\n%s", label, model.FormatServicePortsLabel(svc.Ports))
+	}
 
 	fmt.Fprintf(b, "%s  %s: {\n", indent, svcID)
-	fmt.Fprintf(b, "%s    label: %s\n", indent, QuoteString(fmt.Sprintf("⎈ %s\n%s", svc.Name, svc.Type)))
+	fmt.Fprintf(b, "%s    label: %s\n", indent, QuoteString(label))
 	fmt.Fprintf(b, "%s    style.fill: \"#cce5ff\"\n", indent)
 	fmt.Fprintf(b, "%s  }\n", indent)
 }

--- a/pkg/render/d2_test.go
+++ b/pkg/render/d2_test.go
@@ -10,6 +10,26 @@ import (
 	"github.com/vieitesss/k8s-d2/pkg/model"
 )
 
+func TestFormatServicePortLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		port model.Port
+		want string
+	}{
+		{name: "same target port omits arrow", port: model.Port{Port: 80, TargetPort: "80"}, want: "80"},
+		{name: "named target port kept", port: model.Port{Name: "http", Port: 80, TargetPort: "web"}, want: "http: 80 -> web"},
+		{name: "numeric target port kept", port: model.Port{Name: "metrics", Port: 9090, TargetPort: "9091"}, want: "metrics: 9090 -> 9091"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := model.FormatServicePortLabel(tt.port); got != tt.want {
+				t.Fatalf("FormatServicePortLabel(%+v) = %q, want %q", tt.port, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRenderLegend_IncludesOnlyRenderedResourceTypes(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -299,6 +319,11 @@ func TestRender_EscapesIdentifiersAndLabels(t *testing.T) {
 			Services: []model.Service{{
 				Name: "api.v2-service",
 				Type: "ClusterIP",
+				Ports: []model.Port{{
+					Name:       "http",
+					Port:       80,
+					TargetPort: "api-http",
+				}},
 				Selector: map[string]string{
 					"app.kubernetes.io/name": "api.v2",
 				},
@@ -328,7 +353,7 @@ func TestRender_EscapesIdentifiersAndLabels(t *testing.T) {
 	if !strings.Contains(output, fmt.Sprintf("label: %s", strconv.Quote("● api.v2 (3)"))) {
 		t.Fatalf("expected quoted workload label, output was:\n%s", output)
 	}
-	if !strings.Contains(output, fmt.Sprintf("label: %s", strconv.Quote("⎈ api.v2-service\nClusterIP"))) {
+	if !strings.Contains(output, fmt.Sprintf("label: %s", strconv.Quote("⎈ api.v2-service\nClusterIP\nhttp: 80 -> api-http"))) {
 		t.Fatalf("expected quoted service label with escaped newline, output was:\n%s", output)
 	}
 	if !strings.Contains(output, fmt.Sprintf("label: %s", strconv.Quote("💾 cache.data\n10Gi\n[fast.ssd]"))) {
@@ -336,6 +361,30 @@ func TestRender_EscapesIdentifiersAndLabels(t *testing.T) {
 	}
 	if !strings.Contains(output, fmt.Sprintf("%s -> %s", ServiceID("api.v2-service"), SanitizeID("api.v2"))) {
 		t.Fatalf("expected escaped service-to-workload edge, output was:\n%s", output)
+	}
+}
+
+func TestRender_IncludesServicePortsInLabels(t *testing.T) {
+	cluster := &model.Cluster{Namespaces: []model.Namespace{{
+		Name: "apps",
+		Services: []model.Service{{
+			Name: "api",
+			Type: "ClusterIP",
+			Ports: []model.Port{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: "web",
+			}, {
+				Name:       "metrics",
+				Port:       9090,
+				TargetPort: "9090",
+			}},
+		}},
+	}}}
+
+	output := renderTestCluster(t, cluster)
+	if !strings.Contains(output, fmt.Sprintf("label: %s", strconv.Quote("⎈ api\nClusterIP\nhttp: 80 -> web\nmetrics: 9090"))) {
+		t.Fatalf("expected service ports in label, output was:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Render service ports in D2 service node labels
- Preserve named and omitted targetPort values during fetch and fixture parsing

Closes #57