### PR TITLE
fix: suppress deprecated root warning in quiet mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,9 @@ visualizing namespaces, workloads, services, and their relationships.`,
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {
-	log.Warn("DEPRECATED: Running k8sdd without a subcommand is deprecated. Please use 'k8sdd diagram' instead. This will be removed in v1.0.0.")
+	if !rootOptions.quiet {
+		log.Warn("DEPRECATED: Running k8sdd without a subcommand is deprecated. Please use 'k8sdd diagram' instead. This will be removed in v1.0.0.")
+	}
 	return runGenerate(cmd, args)
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -198,7 +199,7 @@ func TestRunRootQuietSuppressesDeprecatedWarning(t *testing.T) {
 	log.SetOutput(&logOutput)
 	log.SetLevel(log.InfoLevel)
 	t.Cleanup(func() {
-		log.SetOutput(nil)
+		log.SetOutput(os.Stderr)
 		log.SetLevel(originalLevel)
 	})
 
@@ -210,9 +211,6 @@ func TestRunRootQuietSuppressesDeprecatedWarning(t *testing.T) {
 	output := logOutput.String()
 	if strings.Contains(output, "DEPRECATED: Running k8sdd without a subcommand is deprecated") {
 		t.Fatalf("expected quiet root path to suppress deprecated warning, got %q", output)
-	}
-	if strings.Contains(output, "D2 diagram generated successfully") {
-		t.Fatalf("expected quiet root path to suppress info logs, got %q", output)
 	}
 }
 
@@ -231,7 +229,7 @@ func TestRunRootWarnsWhenNotQuiet(t *testing.T) {
 	log.SetOutput(&logOutput)
 	log.SetLevel(log.InfoLevel)
 	t.Cleanup(func() {
-		log.SetOutput(nil)
+		log.SetOutput(os.Stderr)
 		log.SetLevel(originalLevel)
 	})
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/spf13/pflag"
 	"github.com/vieitesss/k8s-d2/pkg/kroki"
 )
@@ -176,5 +179,69 @@ func TestNamespaceFlagSupportsMultipleValues(t *testing.T) {
 				t.Fatalf("expected namespace flag type stringSlice, got %q", got)
 			}
 		})
+	}
+}
+
+func TestRunRootQuietSuppressesDeprecatedWarning(t *testing.T) {
+	originalOptions := rootOptions
+	rootOptions = RootOptions{
+		kubeconfig: "/definitely/missing-kubeconfig",
+		quiet:      true,
+	}
+	t.Cleanup(func() {
+		rootOptions = originalOptions
+	})
+
+	var logOutput bytes.Buffer
+	defaultLogger := log.Default()
+	originalLevel := defaultLogger.GetLevel()
+	log.SetOutput(&logOutput)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(nil)
+		log.SetLevel(originalLevel)
+	})
+
+	err := runRoot(rootCmd, nil)
+	if err == nil {
+		t.Fatal("expected runRoot to fail with invalid kubeconfig")
+	}
+
+	output := logOutput.String()
+	if strings.Contains(output, "DEPRECATED: Running k8sdd without a subcommand is deprecated") {
+		t.Fatalf("expected quiet root path to suppress deprecated warning, got %q", output)
+	}
+	if strings.Contains(output, "D2 diagram generated successfully") {
+		t.Fatalf("expected quiet root path to suppress info logs, got %q", output)
+	}
+}
+
+func TestRunRootWarnsWhenNotQuiet(t *testing.T) {
+	originalOptions := rootOptions
+	rootOptions = RootOptions{
+		kubeconfig: "/definitely/missing-kubeconfig",
+	}
+	t.Cleanup(func() {
+		rootOptions = originalOptions
+	})
+
+	var logOutput bytes.Buffer
+	defaultLogger := log.Default()
+	originalLevel := defaultLogger.GetLevel()
+	log.SetOutput(&logOutput)
+	log.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		log.SetOutput(nil)
+		log.SetLevel(originalLevel)
+	})
+
+	err := runRoot(rootCmd, nil)
+	if err == nil {
+		t.Fatal("expected runRoot to fail with invalid kubeconfig")
+	}
+
+	output := logOutput.String()
+	if !strings.Contains(output, "DEPRECATED: Running k8sdd without a subcommand is deprecated") {
+		t.Fatalf("expected non-quiet root path to emit deprecated warning, got %q", output)
 	}
 }


### PR DESCRIPTION
- Honor --quiet on the deprecated root command path so the warning is not emitted before execution.
- Add regression coverage for quiet and non-quiet deprecated root execution.

Closes #69