### PR TITLE
fix: align --include-storage docs with current PVC behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ k8sdd diagram -i cluster.svg --kroki-base-url https://kroki.internal --kroki-tim
 | `--image` | `-i` | | Output SVG image file (uses Kroki API) |
 | `--kroki-base-url` | | `https://kroki.io` | Kroki base URL for SVG generation |
 | `--kroki-timeout` | | `30s` | Kroki request timeout for SVG generation |
-| `--include-storage` | | `false` | Include PVCs and StorageClasses |
+| `--include-storage` | | `false` | Include PVCs with storage class labels |
 | `--quiet` | `-q` | `false` | Suppress progress indicators and log messages |
 
 > **Note:** `--output` and `--image` are mutually exclusive.
 >
 > `--kroki-base-url` and `--kroki-timeout` are only used with `--image`. When set, the Kroki base URL must not be empty and the timeout must be greater than `0`.
+
+`--include-storage` adds PVC nodes to the diagram and shows each PVC's storage class as label metadata when available. It does not render `StorageClass` objects as separate nodes.
 
 ## Requirements
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
 	rootCmd.PersistentFlags().StringVar(&rootOptions.krokiBaseURL, "kroki-base-url", kroki.DefaultBaseURL, "Kroki base URL for SVG generation")
 	rootCmd.PersistentFlags().DurationVar(&rootOptions.krokiTimeout, "kroki-timeout", kroki.DefaultTimeout, "Kroki request timeout for SVG generation")
-	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC/StorageClass layer")
+	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC layer with storage class labels")
 	rootCmd.PersistentFlags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
 	if err := rootCmd.PersistentFlags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
 		panic(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ type RootOptions struct {
 	quiet          bool
 }
 
+const includeStorageUsage = "include PVC layer with storage class labels"
+
 var rootOptions RootOptions
 
 var rootCmd = &cobra.Command{
@@ -54,7 +56,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&rootOptions.image, "image", "i", "", "output .svg image file. Extension is not needed always SVG file is generated")
 	rootCmd.PersistentFlags().StringVar(&rootOptions.krokiBaseURL, "kroki-base-url", kroki.DefaultBaseURL, "Kroki base URL for SVG generation")
 	rootCmd.PersistentFlags().DurationVar(&rootOptions.krokiTimeout, "kroki-timeout", kroki.DefaultTimeout, "Kroki request timeout for SVG generation")
-	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, "include PVC layer with storage class labels")
+	rootCmd.PersistentFlags().BoolVar(&rootOptions.includeStorage, "include-storage", false, includeStorageUsage)
 	rootCmd.PersistentFlags().IntVar(&rootOptions.gridColumns, "grid-columns", 3, "deprecated: automatic layout is used")
 	if err := rootCmd.PersistentFlags().MarkDeprecated("grid-columns", "automatic layout is now used; this flag has no effect"); err != nil {
 		panic(err)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -48,6 +48,27 @@ func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
 	}
 }
 
+func TestIncludeStorageFlagDescriptionMatchesCurrentBehavior(t *testing.T) {
+	const want = "include PVC layer with storage class labels"
+
+	for _, cmd := range []struct {
+		name string
+		flag *pflag.Flag
+	}{
+		{name: "root", flag: rootCmd.Flag("include-storage")},
+		{name: "diagram", flag: diagramCmd.Flag("include-storage")},
+	} {
+		t.Run(cmd.name, func(t *testing.T) {
+			if cmd.flag == nil {
+				t.Fatalf("expected include-storage flag to be registered")
+			}
+			if cmd.flag.Usage != want {
+				t.Fatalf("expected include-storage usage %q, got %q", want, cmd.flag.Usage)
+			}
+		})
+	}
+}
+
 func TestGridColumnsFlagIsDeprecated(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -49,8 +49,6 @@ func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
 }
 
 func TestIncludeStorageFlagDescriptionMatchesCurrentBehavior(t *testing.T) {
-	const want = "include PVC layer with storage class labels"
-
 	for _, cmd := range []struct {
 		name string
 		flag *pflag.Flag
@@ -62,8 +60,8 @@ func TestIncludeStorageFlagDescriptionMatchesCurrentBehavior(t *testing.T) {
 			if cmd.flag == nil {
 				t.Fatalf("expected include-storage flag to be registered")
 			}
-			if cmd.flag.Usage != want {
-				t.Fatalf("expected include-storage usage %q, got %q", want, cmd.flag.Usage)
+			if cmd.flag.Usage != includeStorageUsage {
+				t.Fatalf("expected include-storage usage %q, got %q", includeStorageUsage, cmd.flag.Usage)
 			}
 		})
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,11 +1,17 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/spf13/pflag"
+	"github.com/vieitesss/k8s-d2/internal/validation"
 	"github.com/vieitesss/k8s-d2/pkg/kroki"
+	"github.com/vieitesss/k8s-d2/pkg/render"
 )
 
 func TestRootAndDiagramExposeSameGenerationFlags(t *testing.T) {
@@ -64,6 +70,45 @@ func TestIncludeStorageFlagDescriptionMatchesCurrentBehavior(t *testing.T) {
 				t.Fatalf("expected include-storage usage %q, got %q", includeStorageUsage, cmd.flag.Usage)
 			}
 		})
+	}
+}
+
+func TestIncludeStorageFlagKeepsPVCOnlyRenderContract(t *testing.T) {
+	fixtureData := loadFixtureFiles(t,
+		filepath.Join("..", "test", "fixtures", "base", "04-statefulsets.yaml"),
+		filepath.Join("..", "test", "fixtures", "storage", "01-storageclass.yaml"),
+		filepath.Join("..", "test", "fixtures", "storage", "02-pvcs.yaml"),
+	)
+
+	cluster, err := validation.NewFixtureParser("k8s-d2-test", true).ParseFixtures(fixtureData)
+	if err != nil {
+		t.Fatalf("failed to parse storage fixtures: %v", err)
+	}
+
+	var buf bytes.Buffer
+	renderer := render.NewD2Renderer(&buf, 0)
+	if err := renderer.Render(cluster); err != nil {
+		t.Fatalf("failed to render storage fixtures: %v", err)
+	}
+
+	output := buf.String()
+	for _, pvcName := range []string{"logs-volume", "data-database-0", "data-database-1"} {
+		if !strings.Contains(output, render.PVCID(pvcName)+": {") {
+			t.Fatalf("expected PVC %q to render in storage output\n%s", pvcName, output)
+		}
+	}
+
+	if got := strings.Count(output, "[standard]"); got != 3 {
+		t.Fatalf("expected 3 PVC storage class labels in storage output, got %d\n%s", got, output)
+	}
+	if strings.Contains(output, render.SanitizeID("standard")+": {") {
+		t.Fatalf("did not expect storage class %q to render as a standalone node\n%s", "standard", output)
+	}
+	if strings.Contains(output, "label: \"standard\"") {
+		t.Fatalf("did not expect storage class %q to render as a standalone label\n%s", "standard", output)
+	}
+	if strings.Contains(output, "StorageClass") {
+		t.Fatalf("did not expect StorageClass resources to render as nodes\n%s", output)
 	}
 }
 
@@ -196,4 +241,19 @@ func TestNamespaceFlagSupportsMultipleValues(t *testing.T) {
 			}
 		})
 	}
+}
+
+func loadFixtureFiles(t *testing.T, paths ...string) [][]byte {
+	t.Helper()
+
+	fixtureData := make([][]byte, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read fixture %q: %v", path, err)
+		}
+		fixtureData = append(fixtureData, data)
+	}
+
+	return fixtureData
 }

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -49,7 +49,7 @@ dagger call fixture-image \
   export --path ./cluster.svg
 ```
 
-Export the SVG with storage resources included:
+Export the SVG with PVCs and storage class labels included:
 
 ```bash
 dagger call fixture-image \

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -602,6 +602,52 @@ func TestParseTestFixtures_IncludesStatefulSetGeneratedPVCsWithStorage(t *testin
 	}
 }
 
+func TestParseTestFixtures_WithStorage_RendersPVCsWithoutStorageClassNodes(t *testing.T) {
+	data, err := loadAllFixtures()
+	if err != nil {
+		t.Fatalf("Failed to load all fixtures: %v", err)
+	}
+
+	cluster, err := parseTestFixtures(data, true)
+	if err != nil {
+		t.Fatalf("Failed to parse all fixtures: %v", err)
+	}
+
+	if len(cluster.Namespaces) != 1 {
+		t.Fatalf("expected one namespace, got %d", len(cluster.Namespaces))
+	}
+
+	expectedStorageClassLabels := 0
+	for _, pvc := range cluster.Namespaces[0].PVCs {
+		if pvc.StorageClass == "standard" {
+			expectedStorageClassLabels++
+		}
+	}
+	if expectedStorageClassLabels == 0 {
+		t.Fatalf("expected parsed storage fixtures to preserve PVC storage class metadata")
+	}
+
+	var buf bytes.Buffer
+	renderer := render.NewD2Renderer(&buf, 0)
+	if err := renderer.Render(cluster); err != nil {
+		t.Fatalf("Failed to render D2: %v", err)
+	}
+
+	output := buf.String()
+	if got := strings.Count(output, "[standard]"); got != expectedStorageClassLabels {
+		t.Fatalf("expected %d PVC storage class labels in output, got %d\n%s", expectedStorageClassLabels, got, output)
+	}
+	if strings.Contains(output, render.SanitizeID("standard")) {
+		t.Fatalf("did not expect storage class %q to render as a standalone node\n%s", "standard", output)
+	}
+	if strings.Contains(output, "label: \"standard\"") {
+		t.Fatalf("did not expect storage class %q to render as a standalone label\n%s", "standard", output)
+	}
+	if strings.Contains(output, "StorageClass") {
+		t.Fatalf("did not expect StorageClass resources to render as nodes\n%s", output)
+	}
+}
+
 // Test constants
 const (
 	testNamespace = "k8s-d2-test"


### PR DESCRIPTION
## Summary
- align \
`--include-storage` help and docs with the current PVC-only behavior
- add a CLI flag test so the storage contract stays explicit

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--include-storage` flag behavior: includes PVCs with storage-class label metadata when available, without rendering StorageClass objects as separate nodes. Updated documentation across multiple files.

* **Tests**
  * Added test to verify flag help text matches current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->