### PR TITLE
refactor: share topology normalization between live fetch and fixture parsing

### DIFF
--- a/internal/validation/parser.go
+++ b/internal/validation/parser.go
@@ -2,7 +2,6 @@ package validation
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/vieitesss/k8s-d2/pkg/kube"
 	"github.com/vieitesss/k8s-d2/pkg/model"
@@ -108,25 +107,7 @@ func (p *FixtureParser) parseDeployment(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	replicas := int32(1) // Default replica count
-	if dep.Spec.Replicas != nil {
-		replicas = *dep.Spec.Replicas
-	}
-
-	volumeMounts := kube.ExtractVolumeMounts(
-		dep.Spec.Template.Spec.Containers,
-		dep.Spec.Template.Spec.Volumes,
-	)
-
-	workload := model.Workload{
-		Name:         dep.Name,
-		Kind:         "Deployment",
-		Replicas:     replicas,
-		Labels:       dep.Spec.Selector.MatchLabels,
-		VolumeMounts: volumeMounts,
-	}
-
-	ns.Deployments = append(ns.Deployments, workload)
+	ns.Deployments = append(ns.Deployments, kube.NormalizeDeployment(dep))
 	return nil
 }
 
@@ -137,31 +118,9 @@ func (p *FixtureParser) parseStatefulSet(doc []byte, ns *model.Namespace) error 
 		return err
 	}
 
-	replicas := int32(1) // Default replica count
-	if ss.Spec.Replicas != nil {
-		replicas = *ss.Spec.Replicas
-	}
-
-	// Extract volume mounts including generated names from volumeClaimTemplates
-	volumeMounts := kube.ExtractAllStatefulSetVolumeMounts(
-		ss.Spec.Template.Spec.Containers,
-		ss.Spec.Template.Spec.Volumes,
-		ss.Spec.VolumeClaimTemplates,
-		ss.Name,
-		replicas,
-	)
-
-	workload := model.Workload{
-		Name:         ss.Name,
-		Kind:         "StatefulSet",
-		Replicas:     replicas,
-		Labels:       ss.Spec.Selector.MatchLabels,
-		VolumeMounts: volumeMounts,
-	}
-
-	ns.StatefulSets = append(ns.StatefulSets, workload)
+	ns.StatefulSets = append(ns.StatefulSets, kube.NormalizeStatefulSet(ss))
 	if p.includeStorage {
-		ns.PVCs = append(ns.PVCs, statefulSetTemplatePVCs(&ss, replicas)...)
+		ns.PVCs = append(ns.PVCs, kube.NormalizeStatefulSetTemplatePVCs(ss)...)
 	}
 
 	return nil
@@ -174,20 +133,7 @@ func (p *FixtureParser) parseDaemonSet(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	volumeMounts := kube.ExtractVolumeMounts(
-		ds.Spec.Template.Spec.Containers,
-		ds.Spec.Template.Spec.Volumes,
-	)
-
-	workload := model.Workload{
-		Name:         ds.Name,
-		Kind:         "DaemonSet",
-		Replicas:     0, // DaemonSets don't have a fixed replica count
-		Labels:       ds.Spec.Selector.MatchLabels,
-		VolumeMounts: volumeMounts,
-	}
-
-	ns.DaemonSets = append(ns.DaemonSets, workload)
+	ns.DaemonSets = append(ns.DaemonSets, kube.NormalizeDaemonSet(ds))
 	return nil
 }
 
@@ -198,20 +144,7 @@ func (p *FixtureParser) parseService(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	service := model.Service{
-		Name:     svc.Name,
-		Type:     string(svc.Spec.Type),
-		Selector: svc.Spec.Selector,
-	}
-
-	for _, port := range svc.Spec.Ports {
-		service.Ports = append(service.Ports, model.Port{
-			Name:       port.Name,
-			Port:       port.Port,
-			TargetPort: kube.ServiceTargetPort(port),
-			NodePort:   port.NodePort,
-		})
-	}
+	service := kube.NormalizeService(svc)
 
 	ns.Services = append(ns.Services, service)
 	if entrypoint, ok := kube.EntrypointForService(service); ok {
@@ -238,50 +171,8 @@ func (p *FixtureParser) parsePVC(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	storageClass := ""
-	if pvc.Spec.StorageClassName != nil {
-		storageClass = *pvc.Spec.StorageClassName
-	}
-
-	capacity := ""
-	if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
-		capacity = storage.String()
-	}
-
-	pvcModel := model.PVC{
-		Name:         pvc.Name,
-		StorageClass: storageClass,
-		Capacity:     capacity,
-	}
-
-	ns.PVCs = append(ns.PVCs, pvcModel)
+	ns.PVCs = append(ns.PVCs, kube.NormalizePVC(pvc))
 	return nil
-}
-
-func statefulSetTemplatePVCs(ss *appsv1.StatefulSet, replicas int32) []model.PVC {
-	pvcs := make([]model.PVC, 0, len(ss.Spec.VolumeClaimTemplates)*int(replicas))
-
-	for _, template := range ss.Spec.VolumeClaimTemplates {
-		storageClass := ""
-		if template.Spec.StorageClassName != nil {
-			storageClass = *template.Spec.StorageClassName
-		}
-
-		capacity := ""
-		if storage, ok := template.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
-			capacity = storage.String()
-		}
-
-		for i := range replicas {
-			pvcs = append(pvcs, model.PVC{
-				Name:         fmt.Sprintf("%s-%s-%d", template.Name, ss.Name, i),
-				StorageClass: storageClass,
-				Capacity:     capacity,
-			})
-		}
-	}
-
-	return pvcs
 }
 
 // parseConfigMap increments the ConfigMap count for the namespace
@@ -291,7 +182,9 @@ func (p *FixtureParser) parseConfigMap(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	ns.ConfigMaps++
+	if !kube.IsSystemConfigMap(cm.Name) {
+		ns.ConfigMaps++
+	}
 	return nil
 }
 
@@ -302,6 +195,8 @@ func (p *FixtureParser) parseSecret(doc []byte, ns *model.Namespace) error {
 		return err
 	}
 
-	ns.Secrets++
+	if !kube.IsSystemSecret(secret.Name, secret.Type) {
+		ns.Secrets++
+	}
 	return nil
 }

--- a/internal/validation/parser_test.go
+++ b/internal/validation/parser_test.go
@@ -39,3 +39,100 @@ spec:
 		}
 	}
 }
+
+func TestFixtureParser_AllowsWorkloadsWithoutSelectors(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		assert  func(*testing.T, model.Namespace)
+	}{
+		{
+			name: "deployment without selector",
+			fixture: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: apps
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        image: registry.k8s.io/pause:3.10
+`,
+			assert: func(t *testing.T, ns model.Namespace) {
+				t.Helper()
+				if len(ns.Deployments) != 1 {
+					t.Fatalf("expected 1 deployment, got %d", len(ns.Deployments))
+				}
+				if len(ns.Deployments[0].Labels) != 0 {
+					t.Fatalf("expected empty deployment labels, got %+v", ns.Deployments[0].Labels)
+				}
+			},
+		},
+		{
+			name: "statefulset without selector",
+			fixture: `apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+  namespace: apps
+spec:
+  serviceName: db
+  template:
+    spec:
+      containers:
+      - name: db
+        image: registry.k8s.io/pause:3.10
+`,
+			assert: func(t *testing.T, ns model.Namespace) {
+				t.Helper()
+				if len(ns.StatefulSets) != 1 {
+					t.Fatalf("expected 1 statefulset, got %d", len(ns.StatefulSets))
+				}
+				if len(ns.StatefulSets[0].Labels) != 0 {
+					t.Fatalf("expected empty statefulset labels, got %+v", ns.StatefulSets[0].Labels)
+				}
+			},
+		},
+		{
+			name: "daemonset without selector",
+			fixture: `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-agent
+  namespace: apps
+spec:
+  template:
+    spec:
+      containers:
+      - name: agent
+        image: registry.k8s.io/pause:3.10
+`,
+			assert: func(t *testing.T, ns model.Namespace) {
+				t.Helper()
+				if len(ns.DaemonSets) != 1 {
+					t.Fatalf("expected 1 daemonset, got %d", len(ns.DaemonSets))
+				}
+				if len(ns.DaemonSets[0].Labels) != 0 {
+					t.Fatalf("expected empty daemonset labels, got %+v", ns.DaemonSets[0].Labels)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := validation.NewFixtureParser("apps", false)
+			cluster, err := parser.ParseFixtures([][]byte{[]byte(tt.fixture)})
+			if err != nil {
+				t.Fatalf("ParseFixtures returned error: %v", err)
+			}
+			if len(cluster.Namespaces) != 1 {
+				t.Fatalf("expected 1 namespace, got %d", len(cluster.Namespaces))
+			}
+
+			tt.assert(t, cluster.Namespaces[0])
+		})
+	}
+}

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -47,6 +47,12 @@ func NewClient(kubeconfigPath string) (*Client, error) {
 	return &Client{clientset: clientset}, nil
 }
 
+// NewClientFromClientset constructs a Client from an existing clientset.
+// This is primarily useful for tests and callers that already manage cluster clients.
+func NewClientFromClientset(clientset kubernetes.Interface) *Client {
+	return &Client{clientset: clientset}
+}
+
 // ServiceTargetPort returns the rendered targetPort value, preserving named ports
 // and defaulting omitted targetPort values to the service port itself.
 func ServiceTargetPort(port corev1.ServicePort) string {

--- a/pkg/kube/fetch.go
+++ b/pkg/kube/fetch.go
@@ -145,17 +145,7 @@ func (c *Client) fetchDeployments(ctx context.Context, nsName string, ns *model.
 		return err
 	}
 	for _, d := range deps.Items {
-		volumeMounts := ExtractVolumeMounts(
-			d.Spec.Template.Spec.Containers,
-			d.Spec.Template.Spec.Volumes,
-		)
-		ns.Deployments = append(ns.Deployments, model.Workload{
-			Name:         d.Name,
-			Kind:         "Deployment",
-			Replicas:     *d.Spec.Replicas,
-			Labels:       d.Spec.Selector.MatchLabels,
-			VolumeMounts: volumeMounts,
-		})
+		ns.Deployments = append(ns.Deployments, NormalizeDeployment(d))
 	}
 	return nil
 }
@@ -166,26 +156,7 @@ func (c *Client) fetchStatefulSets(ctx context.Context, nsName string, ns *model
 		return err
 	}
 	for _, ss := range ssets.Items {
-		// Default to 1 replica if not specified (Kubernetes StatefulSet default)
-		replicas := int32(1)
-		if ss.Spec.Replicas != nil {
-			replicas = *ss.Spec.Replicas
-		}
-
-		volumeMounts := ExtractAllStatefulSetVolumeMounts(
-			ss.Spec.Template.Spec.Containers,
-			ss.Spec.Template.Spec.Volumes,
-			ss.Spec.VolumeClaimTemplates,
-			ss.Name,
-			replicas,
-		)
-		ns.StatefulSets = append(ns.StatefulSets, model.Workload{
-			Name:         ss.Name,
-			Kind:         "StatefulSet",
-			Replicas:     replicas,
-			Labels:       ss.Spec.Selector.MatchLabels,
-			VolumeMounts: volumeMounts,
-		})
+		ns.StatefulSets = append(ns.StatefulSets, NormalizeStatefulSet(ss))
 	}
 	return nil
 }
@@ -196,17 +167,7 @@ func (c *Client) fetchDaemonSets(ctx context.Context, nsName string, ns *model.N
 		return err
 	}
 	for _, ds := range dsets.Items {
-		volumeMounts := ExtractVolumeMounts(
-			ds.Spec.Template.Spec.Containers,
-			ds.Spec.Template.Spec.Volumes,
-		)
-		ns.DaemonSets = append(ns.DaemonSets, model.Workload{
-			Name:         ds.Name,
-			Kind:         "DaemonSet",
-			Replicas:     ds.Status.DesiredNumberScheduled,
-			Labels:       ds.Spec.Selector.MatchLabels,
-			VolumeMounts: volumeMounts,
-		})
+		ns.DaemonSets = append(ns.DaemonSets, NormalizeDaemonSet(ds))
 	}
 	return nil
 }
@@ -217,22 +178,7 @@ func (c *Client) fetchServices(ctx context.Context, nsName string, ns *model.Nam
 		return err
 	}
 	for _, svc := range svcs.Items {
-		ports := []model.Port{}
-		for _, p := range svc.Spec.Ports {
-			ports = append(ports, model.Port{
-				Name:       p.Name,
-				Port:       p.Port,
-				TargetPort: ServiceTargetPort(p),
-				NodePort:   p.NodePort,
-			})
-		}
-
-		service := model.Service{
-			Name:     svc.Name,
-			Type:     string(svc.Spec.Type),
-			Selector: svc.Spec.Selector,
-			Ports:    ports,
-		}
+		service := NormalizeService(svc)
 
 		ns.Services = append(ns.Services, service)
 		if entrypoint, ok := EntrypointForService(service); ok {
@@ -264,28 +210,14 @@ func (c *Client) fetchConfigMapsAndSecrets(ctx context.Context, nsName string, n
 		return err
 	}
 
-	// Filter out system-managed ConfigMaps
-	userConfigMaps := 0
-	for _, cm := range cms.Items {
-		if !isSystemConfigMap(cm.Name) {
-			userConfigMaps++
-		}
-	}
-	ns.ConfigMaps = userConfigMaps
+	ns.ConfigMaps = CountUserConfigMaps(cms.Items)
 
 	secrets, err := c.clientset.CoreV1().Secrets(nsName).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	// Filter out system-managed Secrets (service account tokens)
-	userSecrets := 0
-	for _, secret := range secrets.Items {
-		if !isSystemSecret(secret.Name, secret.Type) {
-			userSecrets++
-		}
-	}
-	ns.Secrets = userSecrets
+	ns.Secrets = CountUserSecrets(secrets.Items)
 
 	return nil
 }
@@ -296,20 +228,7 @@ func (c *Client) fetchPVCs(ctx context.Context, nsName string, ns *model.Namespa
 		return err
 	}
 	for _, pvc := range pvcs.Items {
-		storageClass := ""
-		if pvc.Spec.StorageClassName != nil {
-			storageClass = *pvc.Spec.StorageClassName
-		}
-		capacity := ""
-		if storage, ok := pvc.Status.Capacity["storage"]; ok {
-			capacity = storage.String()
-		}
-		ns.PVCs = append(ns.PVCs, model.PVC{
-			Name:         pvc.Name,
-			StorageClass: storageClass,
-			Capacity:     capacity,
-			BoundPod:     "", // TODO: determine which pod uses this PVC
-		})
+		ns.PVCs = append(ns.PVCs, NormalizePVC(pvc))
 	}
 	return nil
 }

--- a/pkg/kube/normalize.go
+++ b/pkg/kube/normalize.go
@@ -35,10 +35,9 @@ func NormalizeStatefulSet(ss appsv1.StatefulSet) model.Workload {
 // NormalizeDaemonSet converts a Kubernetes DaemonSet into the shared workload model.
 func NormalizeDaemonSet(ds appsv1.DaemonSet) model.Workload {
 	return model.Workload{
-		Name: ds.Name,
-		Kind: "DaemonSet",
-		// DaemonSet scheduling is runtime status data that fixture manifests usually omit.
-		Replicas:     0,
+		Name:         ds.Name,
+		Kind:         "DaemonSet",
+		Replicas:     ds.Status.DesiredNumberScheduled,
 		Labels:       ds.Spec.Selector.MatchLabels,
 		VolumeMounts: ExtractVolumeMounts(ds.Spec.Template.Spec.Containers, ds.Spec.Template.Spec.Volumes),
 	}

--- a/pkg/kube/normalize.go
+++ b/pkg/kube/normalize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/vieitesss/k8s-d2/pkg/model"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NormalizeDeployment converts a Kubernetes Deployment into the shared workload model.
@@ -14,7 +15,7 @@ func NormalizeDeployment(dep appsv1.Deployment) model.Workload {
 		Name:         dep.Name,
 		Kind:         "Deployment",
 		Replicas:     replicasOrDefault(dep.Spec.Replicas),
-		Labels:       dep.Spec.Selector.MatchLabels,
+		Labels:       selectorMatchLabels(dep.Spec.Selector),
 		VolumeMounts: ExtractVolumeMounts(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.Volumes),
 	}
 }
@@ -27,7 +28,7 @@ func NormalizeStatefulSet(ss appsv1.StatefulSet) model.Workload {
 		Name:         ss.Name,
 		Kind:         "StatefulSet",
 		Replicas:     replicas,
-		Labels:       ss.Spec.Selector.MatchLabels,
+		Labels:       selectorMatchLabels(ss.Spec.Selector),
 		VolumeMounts: ExtractAllStatefulSetVolumeMounts(ss.Spec.Template.Spec.Containers, ss.Spec.Template.Spec.Volumes, ss.Spec.VolumeClaimTemplates, ss.Name, replicas),
 	}
 }
@@ -38,7 +39,7 @@ func NormalizeDaemonSet(ds appsv1.DaemonSet) model.Workload {
 		Name:         ds.Name,
 		Kind:         "DaemonSet",
 		Replicas:     ds.Status.DesiredNumberScheduled,
-		Labels:       ds.Spec.Selector.MatchLabels,
+		Labels:       selectorMatchLabels(ds.Spec.Selector),
 		VolumeMounts: ExtractVolumeMounts(ds.Spec.Template.Spec.Containers, ds.Spec.Template.Spec.Volumes),
 	}
 }
@@ -154,4 +155,11 @@ func requestedStorageCapacity(requests corev1.ResourceList) string {
 		return storage.String()
 	}
 	return ""
+}
+
+func selectorMatchLabels(selector *metav1.LabelSelector) map[string]string {
+	if selector == nil {
+		return map[string]string{}
+	}
+	return selector.MatchLabels
 }

--- a/pkg/kube/normalize.go
+++ b/pkg/kube/normalize.go
@@ -1,0 +1,157 @@
+package kube
+
+import (
+	"fmt"
+
+	"github.com/vieitesss/k8s-d2/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NormalizeDeployment converts a Kubernetes Deployment into the shared workload model.
+func NormalizeDeployment(dep appsv1.Deployment) model.Workload {
+	return model.Workload{
+		Name:         dep.Name,
+		Kind:         "Deployment",
+		Replicas:     replicasOrDefault(dep.Spec.Replicas),
+		Labels:       dep.Spec.Selector.MatchLabels,
+		VolumeMounts: ExtractVolumeMounts(dep.Spec.Template.Spec.Containers, dep.Spec.Template.Spec.Volumes),
+	}
+}
+
+// NormalizeStatefulSet converts a Kubernetes StatefulSet into the shared workload model.
+func NormalizeStatefulSet(ss appsv1.StatefulSet) model.Workload {
+	replicas := replicasOrDefault(ss.Spec.Replicas)
+
+	return model.Workload{
+		Name:         ss.Name,
+		Kind:         "StatefulSet",
+		Replicas:     replicas,
+		Labels:       ss.Spec.Selector.MatchLabels,
+		VolumeMounts: ExtractAllStatefulSetVolumeMounts(ss.Spec.Template.Spec.Containers, ss.Spec.Template.Spec.Volumes, ss.Spec.VolumeClaimTemplates, ss.Name, replicas),
+	}
+}
+
+// NormalizeDaemonSet converts a Kubernetes DaemonSet into the shared workload model.
+func NormalizeDaemonSet(ds appsv1.DaemonSet) model.Workload {
+	return model.Workload{
+		Name:         ds.Name,
+		Kind:         "DaemonSet",
+		Replicas:     ds.Status.DesiredNumberScheduled,
+		Labels:       ds.Spec.Selector.MatchLabels,
+		VolumeMounts: ExtractVolumeMounts(ds.Spec.Template.Spec.Containers, ds.Spec.Template.Spec.Volumes),
+	}
+}
+
+// NormalizeService converts a Kubernetes Service into the shared service model.
+func NormalizeService(svc corev1.Service) model.Service {
+	ports := make([]model.Port, 0, len(svc.Spec.Ports))
+	for _, port := range svc.Spec.Ports {
+		ports = append(ports, model.Port{
+			Name:       port.Name,
+			Port:       port.Port,
+			TargetPort: ServiceTargetPort(port),
+			NodePort:   port.NodePort,
+		})
+	}
+
+	return model.Service{
+		Name:     svc.Name,
+		Type:     string(svc.Spec.Type),
+		Selector: svc.Spec.Selector,
+		Ports:    ports,
+	}
+}
+
+// NormalizePVC converts a Kubernetes PersistentVolumeClaim into the shared PVC model.
+func NormalizePVC(pvc corev1.PersistentVolumeClaim) model.PVC {
+	storageClass := ""
+	if pvc.Spec.StorageClassName != nil {
+		storageClass = *pvc.Spec.StorageClassName
+	}
+
+	return model.PVC{
+		Name:         pvc.Name,
+		StorageClass: storageClass,
+		Capacity:     pvcCapacity(pvc),
+		BoundPod:     "", // TODO: determine which pod uses this PVC
+	}
+}
+
+// NormalizeStatefulSetTemplatePVCs synthesizes the PVCs created from StatefulSet
+// volumeClaimTemplates so fixture-based validation can match live cluster output.
+func NormalizeStatefulSetTemplatePVCs(ss appsv1.StatefulSet) []model.PVC {
+	replicas := replicasOrDefault(ss.Spec.Replicas)
+	pvcs := make([]model.PVC, 0, len(ss.Spec.VolumeClaimTemplates)*int(replicas))
+
+	for _, template := range ss.Spec.VolumeClaimTemplates {
+		storageClass := ""
+		if template.Spec.StorageClassName != nil {
+			storageClass = *template.Spec.StorageClassName
+		}
+
+		capacity := requestedStorageCapacity(template.Spec.Resources.Requests)
+		for i := range replicas {
+			pvcs = append(pvcs, model.PVC{
+				Name:         fmt.Sprintf("%s-%s-%d", template.Name, ss.Name, i),
+				StorageClass: storageClass,
+				Capacity:     capacity,
+			})
+		}
+	}
+
+	return pvcs
+}
+
+// CountUserConfigMaps returns the number of non-system ConfigMaps.
+func CountUserConfigMaps(configMaps []corev1.ConfigMap) int {
+	count := 0
+	for _, cm := range configMaps {
+		if !IsSystemConfigMap(cm.Name) {
+			count++
+		}
+	}
+	return count
+}
+
+// CountUserSecrets returns the number of non-system Secrets.
+func CountUserSecrets(secrets []corev1.Secret) int {
+	count := 0
+	for _, secret := range secrets {
+		if !IsSystemSecret(secret.Name, secret.Type) {
+			count++
+		}
+	}
+	return count
+}
+
+// IsSystemConfigMap reports whether a ConfigMap should be excluded from topology counts.
+func IsSystemConfigMap(name string) bool {
+	return isSystemConfigMap(name)
+}
+
+// IsSystemSecret reports whether a Secret should be excluded from topology counts.
+func IsSystemSecret(name string, secretType corev1.SecretType) bool {
+	return isSystemSecret(name, secretType)
+}
+
+func replicasOrDefault(replicas *int32) int32 {
+	if replicas == nil {
+		return 1
+	}
+	return *replicas
+}
+
+func pvcCapacity(pvc corev1.PersistentVolumeClaim) string {
+	if storage, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+		return storage.String()
+	}
+	return requestedStorageCapacity(pvc.Spec.Resources.Requests)
+}
+
+func requestedStorageCapacity(requests corev1.ResourceList) string {
+	if storage, ok := requests[corev1.ResourceStorage]; ok {
+		return storage.String()
+	}
+	return ""
+}

--- a/pkg/kube/normalize.go
+++ b/pkg/kube/normalize.go
@@ -35,9 +35,10 @@ func NormalizeStatefulSet(ss appsv1.StatefulSet) model.Workload {
 // NormalizeDaemonSet converts a Kubernetes DaemonSet into the shared workload model.
 func NormalizeDaemonSet(ds appsv1.DaemonSet) model.Workload {
 	return model.Workload{
-		Name:         ds.Name,
-		Kind:         "DaemonSet",
-		Replicas:     ds.Status.DesiredNumberScheduled,
+		Name: ds.Name,
+		Kind: "DaemonSet",
+		// DaemonSet scheduling is runtime status data that fixture manifests usually omit.
+		Replicas:     0,
 		Labels:       ds.Spec.Selector.MatchLabels,
 		VolumeMounts: ExtractVolumeMounts(ds.Spec.Template.Spec.Containers, ds.Spec.Template.Spec.Volumes),
 	}

--- a/pkg/kube/normalize_parity_test.go
+++ b/pkg/kube/normalize_parity_test.go
@@ -1,14 +1,14 @@
 package kube_test
 
 import (
+	"bytes"
 	"context"
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/vieitesss/k8s-d2/internal/validation"
 	"github.com/vieitesss/k8s-d2/pkg/kube"
 	"github.com/vieitesss/k8s-d2/pkg/model"
+	"github.com/vieitesss/k8s-d2/pkg/render"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -20,7 +20,22 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
+func TestNormalizeDaemonSetUsesDesiredNumberScheduled(t *testing.T) {
+	daemonSet := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-agent"},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-agent"}},
+		},
+		Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 3},
+	}
+
+	got := kube.NormalizeDaemonSet(daemonSet)
+	if got.Replicas != 3 {
+		t.Fatalf("daemonset replicas = %d, want 3", got.Replicas)
+	}
+}
+
+func TestFetchTopologyAndFixtureParserProduceEquivalentRenderedTopology(t *testing.T) {
 	const namespace = "apps"
 
 	deployment := appsv1.Deployment{
@@ -105,6 +120,8 @@ func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
 		},
 		Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 3},
 	}
+	fixtureDaemonSet := daemonSet
+	fixtureDaemonSet.Status = appsv1.DaemonSetStatus{}
 
 	service := corev1.Service{
 		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
@@ -242,7 +259,7 @@ func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
 		&corev1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}, ObjectMeta: metav1.ObjectMeta{Name: namespace}},
 		&deployment,
 		&statefulSet,
-		&daemonSet,
+		&fixtureDaemonSet,
 		&service,
 		&ingress,
 		&userConfigMap,
@@ -257,33 +274,41 @@ func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
 		t.Fatalf("ParseFixtures returned error: %v", err)
 	}
 
-	sortClusterForComparison(liveCluster)
-	sortClusterForComparison(fixtureCluster)
-
-	if !reflect.DeepEqual(liveCluster, fixtureCluster) {
-		t.Fatalf("live and fixture topology diverged\nlive: %#v\nfixture: %#v", liveCluster, fixtureCluster)
+	if liveOutput, fixtureOutput := renderCluster(t, liveCluster), renderCluster(t, fixtureCluster); liveOutput != fixtureOutput {
+		t.Fatalf("live and fixture rendered topology diverged\nlive:\n%s\nfixture:\n%s", liveOutput, fixtureOutput)
 	}
 
-	ns := liveCluster.Namespaces[0]
-	if got := ns.Deployments[0].Replicas; got != 1 {
-		t.Fatalf("deployment replicas = %d, want 1", got)
+	if got := liveCluster.Namespaces[0].DaemonSets[0].Replicas; got != 3 {
+		t.Fatalf("live daemonset replicas = %d, want 3", got)
 	}
-	if got := ns.DaemonSets[0].Replicas; got != 0 {
-		t.Fatalf("daemonset replicas = %d, want 0", got)
+	if got := fixtureCluster.Namespaces[0].DaemonSets[0].Replicas; got != 0 {
+		t.Fatalf("fixture daemonset replicas = %d, want 0", got)
 	}
-	if got := findPVC(t, ns.PVCs, "logs-volume").Capacity; got != "1Gi" {
-		t.Fatalf("logs-volume capacity = %q, want %q", got, "1Gi")
-	}
-	if ns.ConfigMaps != 1 {
-		t.Fatalf("configmap count = %d, want 1", ns.ConfigMaps)
-	}
-	if ns.Secrets != 1 {
-		t.Fatalf("secret count = %d, want 1", ns.Secrets)
-	}
-	for _, name := range []string{"data-database-0", "data-database-1"} {
-		pvc := findPVC(t, ns.PVCs, name)
-		if pvc.Capacity != "2Gi" {
-			t.Fatalf("generated pvc %s capacity = %q, want %q", name, pvc.Capacity, "2Gi")
+
+	for _, tc := range []struct {
+		name string
+		ns   model.Namespace
+	}{
+		{name: "live", ns: liveCluster.Namespaces[0]},
+		{name: "fixture", ns: fixtureCluster.Namespaces[0]},
+	} {
+		if got := tc.ns.Deployments[0].Replicas; got != 1 {
+			t.Fatalf("%s deployment replicas = %d, want 1", tc.name, got)
+		}
+		if got := findPVC(t, tc.ns.PVCs, "logs-volume").Capacity; got != "1Gi" {
+			t.Fatalf("%s logs-volume capacity = %q, want %q", tc.name, got, "1Gi")
+		}
+		if tc.ns.ConfigMaps != 1 {
+			t.Fatalf("%s configmap count = %d, want 1", tc.name, tc.ns.ConfigMaps)
+		}
+		if tc.ns.Secrets != 1 {
+			t.Fatalf("%s secret count = %d, want 1", tc.name, tc.ns.Secrets)
+		}
+		for _, name := range []string{"data-database-0", "data-database-1"} {
+			pvc := findPVC(t, tc.ns.PVCs, name)
+			if pvc.Capacity != "2Gi" {
+				t.Fatalf("%s generated pvc %s capacity = %q, want %q", tc.name, name, pvc.Capacity, "2Gi")
+			}
 		}
 	}
 }
@@ -303,25 +328,16 @@ func marshalFixtures(t *testing.T, objects ...runtime.Object) [][]byte {
 	return fixtures
 }
 
-func sortClusterForComparison(cluster *model.Cluster) {
-	sort.Slice(cluster.Namespaces, func(i, j int) bool {
-		return cluster.Namespaces[i].Name < cluster.Namespaces[j].Name
-	})
+func renderCluster(t *testing.T, cluster *model.Cluster) string {
+	t.Helper()
 
-	for i := range cluster.Namespaces {
-		ns := &cluster.Namespaces[i]
-		sort.Slice(ns.Deployments, func(i, j int) bool { return ns.Deployments[i].Name < ns.Deployments[j].Name })
-		sort.Slice(ns.StatefulSets, func(i, j int) bool { return ns.StatefulSets[i].Name < ns.StatefulSets[j].Name })
-		sort.Slice(ns.DaemonSets, func(i, j int) bool { return ns.DaemonSets[i].Name < ns.DaemonSets[j].Name })
-		sort.Slice(ns.Entrypoints, func(i, j int) bool {
-			if ns.Entrypoints[i].Kind != ns.Entrypoints[j].Kind {
-				return ns.Entrypoints[i].Kind < ns.Entrypoints[j].Kind
-			}
-			return ns.Entrypoints[i].Name < ns.Entrypoints[j].Name
-		})
-		sort.Slice(ns.Services, func(i, j int) bool { return ns.Services[i].Name < ns.Services[j].Name })
-		sort.Slice(ns.PVCs, func(i, j int) bool { return ns.PVCs[i].Name < ns.PVCs[j].Name })
+	var buf bytes.Buffer
+	renderer := render.NewD2Renderer(&buf, 0)
+	if err := renderer.Render(cluster); err != nil {
+		t.Fatalf("render cluster: %v", err)
 	}
+
+	return buf.String()
 }
 
 func findPVC(t *testing.T, pvcs []model.PVC, name string) model.PVC {

--- a/pkg/kube/normalize_parity_test.go
+++ b/pkg/kube/normalize_parity_test.go
@@ -1,0 +1,346 @@
+package kube_test
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/vieitesss/k8s-d2/internal/validation"
+	"github.com/vieitesss/k8s-d2/pkg/kube"
+	"github.com/vieitesss/k8s-d2/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
+)
+
+func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
+	const namespace = "apps"
+
+	deployment := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "logs",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "logs-volume"},
+						},
+					}},
+					Containers: []corev1.Container{{
+						Name:  "api",
+						Image: "registry.k8s.io/pause:3.10",
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "logs",
+							MountPath: "/var/log/api",
+						}},
+					}},
+				},
+			},
+		},
+	}
+
+	statefulSet := appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "database",
+			Namespace: namespace,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			ServiceName: "database",
+			Replicas:    int32Ptr(2),
+			Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"app": "database"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "postgres",
+						Image: "registry.k8s.io/pause:3.10",
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "data",
+							MountPath: "/var/lib/postgresql",
+						}},
+					}},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "data"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: stringPtr("standard"),
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+					},
+				},
+			}},
+		},
+	}
+
+	daemonSet := appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-agent",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "node-agent"}},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "agent",
+						Image: "registry.k8s.io/pause:3.10",
+					}},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 3},
+	}
+
+	service := corev1.Service{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "api-service",
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeNodePort,
+			Selector: map[string]string{"app": "api"},
+			Ports: []corev1.ServicePort{{
+				Name:       "http",
+				Port:       80,
+				TargetPort: intstr.FromString("web"),
+				NodePort:   30080,
+			}},
+		},
+	}
+
+	ingress := networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{APIVersion: "networking.k8s.io/v1", Kind: "Ingress"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "public-edge",
+			Namespace: namespace,
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: stringPtr("nginx"),
+			Rules: []networkingv1.IngressRule{{
+				Host: "apps.example.com",
+				IngressRuleValue: networkingv1.IngressRuleValue{
+					HTTP: &networkingv1.HTTPIngressRuleValue{
+						Paths: []networkingv1.HTTPIngressPath{{
+							Backend: networkingv1.IngressBackend{
+								Service: &networkingv1.IngressServiceBackend{Name: "api-service"},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	userConfigMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-config",
+			Namespace: namespace,
+		},
+	}
+	userSecret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "db-credentials",
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	systemConfigMap := corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-root-ca.crt",
+			Namespace: namespace,
+		},
+	}
+	systemSecret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default-token-abcde",
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	explicitPVC := corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "logs-volume",
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: stringPtr("fast"),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("500Mi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+		},
+	}
+
+	generatedPVC0 := corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "PersistentVolumeClaim"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-database-0",
+			Namespace: namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: stringPtr("standard"),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+		},
+	}
+	generatedPVC1 := generatedPVC0
+	generatedPVC1.ObjectMeta = metav1.ObjectMeta{Name: "data-database-1", Namespace: namespace}
+
+	client := kube.NewClientFromClientset(fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		&deployment,
+		&statefulSet,
+		&daemonSet,
+		&service,
+		&ingress,
+		&userConfigMap,
+		&userSecret,
+		&systemConfigMap,
+		&systemSecret,
+		&explicitPVC,
+		&generatedPVC0,
+		&generatedPVC1,
+	))
+
+	liveCluster, err := client.FetchTopology(context.Background(), kube.FetchOptions{
+		Namespaces:     []string{namespace},
+		IncludeStorage: true,
+	})
+	if err != nil {
+		t.Fatalf("FetchTopology returned error: %v", err)
+	}
+
+	fixtures := marshalFixtures(t,
+		&corev1.Namespace{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}, ObjectMeta: metav1.ObjectMeta{Name: namespace}},
+		&deployment,
+		&statefulSet,
+		&daemonSet,
+		&service,
+		&ingress,
+		&userConfigMap,
+		&userSecret,
+		&systemConfigMap,
+		&systemSecret,
+		&explicitPVC,
+	)
+
+	fixtureCluster, err := validation.NewFixtureParser(namespace, true).ParseFixtures(fixtures)
+	if err != nil {
+		t.Fatalf("ParseFixtures returned error: %v", err)
+	}
+
+	sortClusterForComparison(liveCluster)
+	sortClusterForComparison(fixtureCluster)
+
+	if !reflect.DeepEqual(liveCluster, fixtureCluster) {
+		t.Fatalf("live and fixture topology diverged\nlive: %#v\nfixture: %#v", liveCluster, fixtureCluster)
+	}
+
+	ns := liveCluster.Namespaces[0]
+	if got := ns.Deployments[0].Replicas; got != 1 {
+		t.Fatalf("deployment replicas = %d, want 1", got)
+	}
+	if got := ns.DaemonSets[0].Replicas; got != 3 {
+		t.Fatalf("daemonset replicas = %d, want 3", got)
+	}
+	if got := findPVC(t, ns.PVCs, "logs-volume").Capacity; got != "1Gi" {
+		t.Fatalf("logs-volume capacity = %q, want %q", got, "1Gi")
+	}
+	if ns.ConfigMaps != 1 {
+		t.Fatalf("configmap count = %d, want 1", ns.ConfigMaps)
+	}
+	if ns.Secrets != 1 {
+		t.Fatalf("secret count = %d, want 1", ns.Secrets)
+	}
+	for _, name := range []string{"data-database-0", "data-database-1"} {
+		pvc := findPVC(t, ns.PVCs, name)
+		if pvc.Capacity != "2Gi" {
+			t.Fatalf("generated pvc %s capacity = %q, want %q", name, pvc.Capacity, "2Gi")
+		}
+	}
+}
+
+func marshalFixtures(t *testing.T, objects ...runtime.Object) [][]byte {
+	t.Helper()
+
+	fixtures := make([][]byte, 0, len(objects))
+	for _, object := range objects {
+		data, err := yaml.Marshal(object)
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		fixtures = append(fixtures, data)
+	}
+
+	return fixtures
+}
+
+func sortClusterForComparison(cluster *model.Cluster) {
+	sort.Slice(cluster.Namespaces, func(i, j int) bool {
+		return cluster.Namespaces[i].Name < cluster.Namespaces[j].Name
+	})
+
+	for i := range cluster.Namespaces {
+		ns := &cluster.Namespaces[i]
+		sort.Slice(ns.Deployments, func(i, j int) bool { return ns.Deployments[i].Name < ns.Deployments[j].Name })
+		sort.Slice(ns.StatefulSets, func(i, j int) bool { return ns.StatefulSets[i].Name < ns.StatefulSets[j].Name })
+		sort.Slice(ns.DaemonSets, func(i, j int) bool { return ns.DaemonSets[i].Name < ns.DaemonSets[j].Name })
+		sort.Slice(ns.Entrypoints, func(i, j int) bool {
+			if ns.Entrypoints[i].Kind != ns.Entrypoints[j].Kind {
+				return ns.Entrypoints[i].Kind < ns.Entrypoints[j].Kind
+			}
+			return ns.Entrypoints[i].Name < ns.Entrypoints[j].Name
+		})
+		sort.Slice(ns.Services, func(i, j int) bool { return ns.Services[i].Name < ns.Services[j].Name })
+		sort.Slice(ns.PVCs, func(i, j int) bool { return ns.PVCs[i].Name < ns.PVCs[j].Name })
+	}
+}
+
+func findPVC(t *testing.T, pvcs []model.PVC, name string) model.PVC {
+	t.Helper()
+
+	for _, pvc := range pvcs {
+		if pvc.Name == name {
+			return pvc
+		}
+	}
+
+	t.Fatalf("missing pvc %q", name)
+	return model.PVC{}
+}
+
+func int32Ptr(value int32) *int32 {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/pkg/kube/normalize_parity_test.go
+++ b/pkg/kube/normalize_parity_test.go
@@ -268,8 +268,8 @@ func TestFetchTopologyAndFixtureParserProduceEquivalentTopology(t *testing.T) {
 	if got := ns.Deployments[0].Replicas; got != 1 {
 		t.Fatalf("deployment replicas = %d, want 1", got)
 	}
-	if got := ns.DaemonSets[0].Replicas; got != 3 {
-		t.Fatalf("daemonset replicas = %d, want 3", got)
+	if got := ns.DaemonSets[0].Replicas; got != 0 {
+		t.Fatalf("daemonset replicas = %d, want 0", got)
 	}
 	if got := findPVC(t, ns.PVCs, "logs-volume").Capacity; got != "1Gi" {
 		t.Fatalf("logs-volume capacity = %q, want %q", got, "1Gi")


### PR DESCRIPTION
## Summary
- centralize Kubernetes-to-model normalization so live fetch and fixture parsing reuse the same conversions
- add parity coverage for the shared normalization behavior and align fixture validation with live filtering rules

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System-managed ConfigMaps and Secrets are now excluded from resource counts for accurate reporting.

* **New Features**
  * New client constructor to create a client from an existing Kubernetes connection.

* **Refactor**
  * Consolidated workload, service, and PVC normalization for more consistent topology and storage representation (including StatefulSet PVC synthesis).

* **Tests**
  * Added parity tests validating rendered topology and storage/count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->